### PR TITLE
♻️refactor: クイズ退出確認ダイアログを quiz_core の QuizExitScope に共通化

### DIFF
--- a/packages/quiz_core/lib/quiz_core.dart
+++ b/packages/quiz_core/lib/quiz_core.dart
@@ -21,4 +21,5 @@ export 'src/providers/sound_providers.dart';
 export 'src/widgets/quiz_result_overlay.dart';
 export 'src/widgets/skeleton_dashboard.dart';
 export 'src/widgets/stage_card.dart';
+export 'src/widgets/quiz_exit_scope.dart';
 export 'src/widgets/unreadable_text.dart';

--- a/packages/quiz_core/lib/src/widgets/quiz_exit_scope.dart
+++ b/packages/quiz_core/lib/src/widgets/quiz_exit_scope.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+import 'package:quiz_core/i18n/strings.g.dart';
+import 'package:quiz_core/src/entities/quiz_state.dart';
+
+/// プレイ中にバック操作が行われた際に退出確認ダイアログを表示する PopScope ラッパー。
+///
+/// [quizStatus] が [QuizStatus.playing] の間はシステムバック・スワイプを補足し、
+/// 確認ダイアログを経由してのみ画面を閉じられるようにする。
+///
+/// ### 標準的な使い方
+/// ```dart
+/// QuizExitScope(
+///   quizStatus: quizStatus,
+///   child: Scaffold(...),
+/// )
+/// ```
+///
+/// ### カスタム `canPop` が必要な場合
+/// [showConfirmDialog] を直接呼び出して独自の [PopScope] と組み合わせる。
+/// ```dart
+/// PopScope(
+///   canPop: customCondition,
+///   onPopInvokedWithResult: (didPop, _) async {
+///     if (didPop) return;
+///     final confirmed = await QuizExitScope.showConfirmDialog(context);
+///     if (confirmed == true && context.mounted) Navigator.of(context).pop();
+///   },
+///   child: child,
+/// )
+/// ```
+class QuizExitScope extends StatelessWidget {
+  const QuizExitScope({
+    super.key,
+    required this.quizStatus,
+    required this.child,
+  });
+
+  final QuizStatus quizStatus;
+  final Widget child;
+
+  /// 退出確認ダイアログを表示し、ユーザーの選択（true: 終了 / false: 続ける）を返す。
+  ///
+  /// ダイアログテキストは [quiz_core] の翻訳リソースを使用する。
+  static Future<bool?> showConfirmDialog(BuildContext context) {
+    return showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: Text(t.quiz.exitDialogTitle),
+        content: Text(t.quiz.exitDialogContent),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: Text(t.quiz.exitDialogContinue),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: Text(t.quiz.exitDialogExit),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return PopScope(
+      canPop: quizStatus != QuizStatus.playing,
+      onPopInvokedWithResult: (didPop, _) async {
+        if (didPop) return;
+        final confirmed = await showConfirmDialog(context);
+        if (confirmed == true && context.mounted) {
+          Navigator.of(context).pop();
+        }
+      },
+      child: child,
+    );
+  }
+}

--- a/packages/quiz_core/lib/src/widgets/quiz_exit_scope.dart
+++ b/packages/quiz_core/lib/src/widgets/quiz_exit_scope.dart
@@ -28,7 +28,7 @@ import 'package:quiz_core/src/entities/quiz_state.dart';
 ///   child: child,
 /// )
 /// ```
-class QuizExitScope extends StatelessWidget {
+class QuizExitScope extends StatefulWidget {
   const QuizExitScope({
     super.key,
     required this.quizStatus,
@@ -62,17 +62,32 @@ class QuizExitScope extends StatelessWidget {
   }
 
   @override
+  State<QuizExitScope> createState() => _QuizExitScopeState();
+}
+
+class _QuizExitScopeState extends State<QuizExitScope> {
+  bool _isConfirmDialogOpen = false;
+
+  @override
   Widget build(BuildContext context) {
     return PopScope(
-      canPop: quizStatus != QuizStatus.playing,
+      canPop: widget.quizStatus != QuizStatus.playing,
       onPopInvokedWithResult: (didPop, _) async {
         if (didPop) return;
-        final confirmed = await showConfirmDialog(context);
-        if (confirmed == true && context.mounted) {
-          Navigator.of(context).pop();
+        if (_isConfirmDialogOpen) return;
+        setState(() => _isConfirmDialogOpen = true);
+        try {
+          final confirmed = await QuizExitScope.showConfirmDialog(context);
+          if (confirmed == true && context.mounted) {
+            Navigator.of(context).pop();
+          }
+        } finally {
+          if (mounted) {
+            setState(() => _isConfirmDialogOpen = false);
+          }
         }
       },
-      child: child,
+      child: widget.child,
     );
   }
 }

--- a/packages/quiz_core/test/widgets/quiz_exit_scope_test.dart
+++ b/packages/quiz_core/test/widgets/quiz_exit_scope_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:quiz_core/quiz_core.dart';
+
+void main() {
+  setUp(() {
+    LocaleSettings.setLocale(AppLocale.ja);
+  });
+
+  Future<void> pumpWithNavigator(
+    WidgetTester tester,
+    QuizStatus status,
+  ) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (context) => TextButton(
+            onPressed: () {
+              Navigator.of(context).push(
+                MaterialPageRoute<void>(
+                  builder: (_) => QuizExitScope(
+                    quizStatus: status,
+                    child: const Scaffold(body: Text('クイズ画面')),
+                  ),
+                ),
+              );
+            },
+            child: const Text('スタート'),
+          ),
+        ),
+      ),
+    );
+    await tester.tap(find.text('スタート'));
+    await tester.pumpAndSettle();
+    expect(find.text('クイズ画面'), findsOneWidget);
+  }
+
+  group('QuizExitScope', () {
+    testWidgets('QuizStatus.playing のときはバック操作で確認ダイアログが表示される', (tester) async {
+      await pumpWithNavigator(tester, QuizStatus.playing);
+
+      await tester.binding.handlePopRoute();
+      await tester.pump();
+
+      expect(find.byType(AlertDialog), findsOneWidget);
+    });
+
+    testWidgets('QuizStatus.playing 以外のときはダイアログを表示せず即座に戻れる', (tester) async {
+      await pumpWithNavigator(tester, QuizStatus.idle);
+
+      await tester.binding.handlePopRoute();
+      await tester.pumpAndSettle();
+
+      expect(find.byType(AlertDialog), findsNothing);
+      expect(find.text('スタート'), findsOneWidget);
+    });
+  });
+}

--- a/packages/quizzes/alarm/lib/src/presentation/alarm_app_screen.dart
+++ b/packages/quizzes/alarm/lib/src/presentation/alarm_app_screen.dart
@@ -44,32 +44,8 @@ class AlarmListScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     final sq = context.sq;
 
-    return PopScope(
-      canPop: quizStatus != QuizStatus.playing,
-      onPopInvokedWithResult: (didPop, _) async {
-        if (didPop) return;
-        // プレイ中に戻るジェスチャー → 確認ダイアログ
-        final confirmed = await showDialog<bool>(
-          context: context,
-          builder: (ctx) => AlertDialog(
-            title: const Text('ゲームを中断しますか？'),
-            content: const Text('プレイ中のゲームを終了します。'),
-            actions: [
-              TextButton(
-                onPressed: () => Navigator.of(ctx).pop(false),
-                child: const Text('続ける'),
-              ),
-              TextButton(
-                onPressed: () => Navigator.of(ctx).pop(true),
-                child: const Text('終了する'),
-              ),
-            ],
-          ),
-        );
-        if (confirmed == true && context.mounted) {
-          Navigator.of(context).pop();
-        }
-      },
+    return QuizExitScope(
+      quizStatus: quizStatus,
       child: Scaffold(
         backgroundColor: Theme.of(context).colorScheme.surface,
         appBar: AppBar(

--- a/packages/quizzes/chat/lib/src/presentation/chat_app_shell.dart
+++ b/packages/quizzes/chat/lib/src/presentation/chat_app_shell.dart
@@ -105,31 +105,8 @@ class ChatAppShell extends StatelessWidget {
             ],
           );
 
-    return PopScope(
-      canPop: quizStatus != QuizStatus.playing,
-      onPopInvokedWithResult: (didPop, _) async {
-        if (didPop) return;
-        final confirmed = await showDialog<bool>(
-          context: context,
-          builder: (ctx) => AlertDialog(
-            title: const Text('ゲームを中断しますか？'),
-            content: const Text('プレイ中のゲームを終了します。'),
-            actions: [
-              TextButton(
-                onPressed: () => Navigator.of(ctx).pop(false),
-                child: const Text('続ける'),
-              ),
-              TextButton(
-                onPressed: () => Navigator.of(ctx).pop(true),
-                child: const Text('終了する'),
-              ),
-            ],
-          ),
-        );
-        if (confirmed == true && context.mounted) {
-          Navigator.of(context).pop();
-        }
-      },
+    return QuizExitScope(
+      quizStatus: quizStatus,
       child: body,
     );
   }

--- a/packages/quizzes/map/lib/src/presentation/map_app_screen.dart
+++ b/packages/quizzes/map/lib/src/presentation/map_app_screen.dart
@@ -3,8 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:quiz_core/quiz_core.dart';
 
 import '../domain/entities/map_place.dart';
-import '../domain/map_catalog.dart';
 import '../i18n/map_translations_extension.dart';
+import '../domain/map_catalog.dart';
 import '../../i18n/strings.g.dart' as $map;
 
 /// Google マップ風の地図UIベーススクリーン
@@ -81,35 +81,11 @@ class MapAppScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final s = context.s;
     final sq = context.sq;
     final bottomInset = MediaQuery.paddingOf(context).bottom;
 
-    return PopScope(
-      canPop: quizStatus != QuizStatus.playing,
-      onPopInvokedWithResult: (didPop, _) async {
-        if (didPop) return;
-        final confirmed = await showDialog<bool>(
-          context: context,
-          builder: (ctx) => AlertDialog(
-            title: Text(s.common.confirmQuitTitle),
-            content: Text(s.common.confirmQuitMessage),
-            actions: [
-              TextButton(
-                onPressed: () => Navigator.of(ctx).pop(false),
-                child: Text(s.common.continueGame),
-              ),
-              TextButton(
-                onPressed: () => Navigator.of(ctx).pop(true),
-                child: Text(s.common.quitGame),
-              ),
-            ],
-          ),
-        );
-        if (confirmed == true && context.mounted) {
-          Navigator.of(context).pop();
-        }
-      },
+    return QuizExitScope(
+      quizStatus: quizStatus,
       child: Scaffold(
         backgroundColor: Theme.of(context).extension<MapAppTheme>()!.mapBackground,
       body: Stack(

--- a/packages/quizzes/payment/lib/src/presentation/payment_app_screen.dart
+++ b/packages/quizzes/payment/lib/src/presentation/payment_app_screen.dart
@@ -125,41 +125,14 @@ class _PaymentHomeScreenState extends State<PaymentHomeScreen> {
     super.dispose();
   }
 
-  Future<bool?> _showExitConfirmDialog() {
-    return showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: Text(t.quiz.exitDialogTitle),
-        content: Text(t.quiz.exitDialogContent),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(ctx).pop(false),
-            child: Text(t.quiz.exitDialogContinue),
-          ),
-          TextButton(
-            onPressed: () => Navigator.of(ctx).pop(true),
-            child: Text(t.quiz.exitDialogExit),
-          ),
-        ],
-      ),
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
     final sq = context.sq;
 
     final ext = Theme.of(context).extension<PaymentAppTheme>()!;
 
-    return PopScope(
-      canPop: widget.quizStatus != QuizStatus.playing,
-      onPopInvokedWithResult: (didPop, _) async {
-        if (didPop) return;
-        final confirmed = await _showExitConfirmDialog();
-        if (confirmed == true && mounted) {
-          Navigator.of(context).pop();
-        }
-      },
+    return QuizExitScope(
+      quizStatus: widget.quizStatus,
       child: Scaffold(
       backgroundColor: ext.brandColor,
       floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,

--- a/packages/quizzes/shopping/lib/src/presentation/cart_quiz/cart_quiz_screen.dart
+++ b/packages/quizzes/shopping/lib/src/presentation/cart_quiz/cart_quiz_screen.dart
@@ -44,31 +44,8 @@ class _CartQuizScreenState extends ConsumerState<CartQuizScreen> {
     final quizState = ref.watch(cartQuizProvider);
     final missionText = context.s.cart.missionText;
 
-    return PopScope(
-      canPop: quizState.status != QuizStatus.playing,
-      onPopInvokedWithResult: (didPop, _) async {
-        if (didPop) return;
-        final confirmed = await showDialog<bool>(
-          context: context,
-          builder: (ctx) => AlertDialog(
-            title: const Text('ゲームを中断しますか？'),
-            content: const Text('プレイ中のゲームを終了します。'),
-            actions: [
-              TextButton(
-                onPressed: () => Navigator.of(ctx).pop(false),
-                child: const Text('続ける'),
-              ),
-              TextButton(
-                onPressed: () => Navigator.of(ctx).pop(true),
-                child: const Text('終了する'),
-              ),
-            ],
-          ),
-        );
-        if (confirmed == true && context.mounted) {
-          Navigator.of(context).pop();
-        }
-      },
+    return QuizExitScope(
+      quizStatus: quizState.status,
       child: Stack(
         children: [
           Scaffold(

--- a/packages/quizzes/shopping/lib/src/presentation/checkout_quiz/checkout_quiz_screen.dart
+++ b/packages/quizzes/shopping/lib/src/presentation/checkout_quiz/checkout_quiz_screen.dart
@@ -49,31 +49,8 @@ class _CheckoutQuizScreenState extends ConsumerState<CheckoutQuizScreen> {
       }
     });
 
-    return PopScope(
-      canPop: quizState.status != QuizStatus.playing,
-      onPopInvokedWithResult: (didPop, _) async {
-        if (didPop) return;
-        final confirmed = await showDialog<bool>(
-          context: context,
-          builder: (ctx) => AlertDialog(
-            title: const Text('ゲームを中断しますか？'),
-            content: const Text('プレイ中のゲームを終了します。'),
-            actions: [
-              TextButton(
-                onPressed: () => Navigator.of(ctx).pop(false),
-                child: const Text('続ける'),
-              ),
-              TextButton(
-                onPressed: () => Navigator.of(ctx).pop(true),
-                child: const Text('終了する'),
-              ),
-            ],
-          ),
-        );
-        if (confirmed == true && context.mounted) {
-          Navigator.of(context).pop();
-        }
-      },
+    return QuizExitScope(
+      quizStatus: quizState.status,
       child: Stack(
         children: [
           Scaffold(

--- a/packages/quizzes/shopping/lib/src/presentation/shopping_app.dart
+++ b/packages/quizzes/shopping/lib/src/presentation/shopping_app.dart
@@ -144,7 +144,7 @@ class _ShoppingAppState extends State<ShoppingApp> {
           setState(() => _showOrderHistory = false);
           return;
         }
-        final confirmed = await _showExitConfirmDialog();
+        final confirmed = await QuizExitScope.showConfirmDialog(context);
         if (confirmed == true && mounted) {
           Navigator.of(context).pop();
         }
@@ -178,26 +178,6 @@ class _ShoppingAppState extends State<ShoppingApp> {
             ),
           // クイズ固有のオーバーレイ（カットイン・リザルト等）
           ...widget.overlays,
-        ],
-      ),
-    );
-  }
-
-  Future<bool?> _showExitConfirmDialog() {
-    return showDialog<bool>(
-      context: context,
-      builder: (ctx) => AlertDialog(
-        title: const Text('ゲームを中断しますか？'),
-        content: const Text('プレイ中のゲームを終了します。'),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(ctx).pop(false),
-            child: const Text('続ける'),
-          ),
-          TextButton(
-            onPressed: () => Navigator.of(ctx).pop(true),
-            child: const Text('終了する'),
-          ),
         ],
       ),
     );

--- a/packages/quizzes/streaming/lib/src/presentation/streaming_player_screen.dart
+++ b/packages/quizzes/streaming/lib/src/presentation/streaming_player_screen.dart
@@ -2,8 +2,8 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:quiz_core/quiz_core.dart';
 import 'package:streaming/src/domain/entities/streaming_video.dart';
-import 'package:streaming/src/domain/streaming_catalog.dart';
 import 'package:streaming/src/i18n/streaming_translations_extension.dart';
+import 'package:streaming/src/domain/streaming_catalog.dart';
 
 /// YouTube 風プレイヤー共通UI
 class StreamingPlayerScreen extends StatelessWidget {
@@ -98,31 +98,8 @@ class StreamingPlayerScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return PopScope(
-      canPop: quizStatus != QuizStatus.playing,
-      onPopInvokedWithResult: (didPop, _) async {
-        if (didPop) return;
-        final confirmed = await showDialog<bool>(
-          context: context,
-          builder: (ctx) => AlertDialog(
-            title: Text(context.s.common.quitConfirmTitle),
-            content: Text(context.s.common.quitConfirmMessage),
-            actions: [
-              TextButton(
-                onPressed: () => Navigator.of(ctx).pop(false),
-                child: Text(context.s.common.continueButton),
-              ),
-              TextButton(
-                onPressed: () => Navigator.of(ctx).pop(true),
-                child: Text(context.s.common.quitButton),
-              ),
-            ],
-          ),
-        );
-        if (confirmed == true && context.mounted) {
-          Navigator.of(context).pop();
-        }
-      },
+    return QuizExitScope(
+      quizStatus: quizStatus,
       child: Scaffold(
         backgroundColor: Theme.of(context).extension<StreamingAppTheme>()!.playerBackground,
         body: Stack(


### PR DESCRIPTION
各クイズカテゴリ（payment/streaming/map/shopping/alarm/chat）で同一のダイアログが 個別定義・ハードコードされており、翻訳管理の不整合や重複コードが生じていたため。
QuizExitScope ウィジェット（PopScope + 確認ダイアログ）および静的メソッド
showConfirmDialog を quiz_core に追加し、全パッケージで共通利用できるようにした。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * クイズ実施中に戻るボタンで意図しない終了を防止する確認ダイアログを追加。すべてのクイズで一貫した終了動作を実装しました。

* **改善**
  * クイズ終了時の確認フローを統一し、ユーザー体験を向上。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->