### PR TITLE
♻️refactor: shoppingクイズのinitial()からtimeLimitSecondsパラメータを削除

### DIFF
--- a/packages/quizzes/alarm/lib/src/presentation/quiz1_add_alarm/add_alarm_quiz_notifier.dart
+++ b/packages/quizzes/alarm/lib/src/presentation/quiz1_add_alarm/add_alarm_quiz_notifier.dart
@@ -7,7 +7,6 @@ import 'package:system/system.dart';
 
 import '../../application/quiz_add_alarm_use_case.dart';
 import '../../domain/alarm_catalog.dart';
-import '../../domain/alarm_quiz_config.dart';
 import '../../infrastructure/alarm_quiz_repository_provider.dart';
 import 'add_alarm_quiz_state.dart';
 
@@ -28,7 +27,6 @@ class AddAlarmQuizNotifier extends AutoDisposeNotifier<AddAlarmQuizState> {
     ref.onDispose(() => _timer?.cancel());
     return AddAlarmQuizState.initial(
       draft: AlarmCatalog.newAlarmDefault,
-      timeLimitSeconds: AlarmQuizConfig.quiz1AddAlarmTimeLimitSeconds,
     );
   }
 
@@ -37,7 +35,6 @@ class AddAlarmQuizNotifier extends AutoDisposeNotifier<AddAlarmQuizState> {
     _timer?.cancel();
     state = AddAlarmQuizState.initial(
       draft: AlarmCatalog.newAlarmDefault,
-      timeLimitSeconds: AlarmQuizConfig.quiz1AddAlarmTimeLimitSeconds,
     ).copyWith(
       status: QuizStatus.playing,
       startedAt: clock.now(),
@@ -100,7 +97,6 @@ class AddAlarmQuizNotifier extends AutoDisposeNotifier<AddAlarmQuizState> {
     ref.read(analyticsServiceProvider).logQuizRetried(quizId: _quizId);
     state = AddAlarmQuizState.initial(
       draft: AlarmCatalog.newAlarmDefault,
-      timeLimitSeconds: AlarmQuizConfig.quiz1AddAlarmTimeLimitSeconds,
     ).copyWith(
       status: QuizStatus.playing,
       startedAt: clock.now(),

--- a/packages/quizzes/alarm/lib/src/presentation/quiz1_add_alarm/add_alarm_quiz_state.dart
+++ b/packages/quizzes/alarm/lib/src/presentation/quiz1_add_alarm/add_alarm_quiz_state.dart
@@ -1,5 +1,6 @@
 import 'package:quiz_core/quiz_core.dart';
 
+import '../../domain/alarm_quiz_config.dart';
 import '../../domain/entities/alarm_item.dart';
 
 /// Quiz 1「アラームを追加する」の状態
@@ -19,7 +20,6 @@ class AddAlarmQuizState extends QuizStateBase {
   /// 初期状態を生成する
   factory AddAlarmQuizState.initial({
     required AlarmItem draft,
-    int timeLimitSeconds = 30,
   }) =>
       AddAlarmQuizState(
         status: QuizStatus.idle,
@@ -29,7 +29,7 @@ class AddAlarmQuizState extends QuizStateBase {
         showEditForm: false,
         draftAlarm: draft,
         alarmSaved: false,
-        remainingSeconds: timeLimitSeconds,
+        remainingSeconds: AlarmQuizConfig.quiz1AddAlarmTimeLimitSeconds,
       );
 
   /// 編集フォームを表示中か

--- a/packages/quizzes/alarm/lib/src/presentation/quiz2_set_weekdays/set_weekdays_quiz_notifier.dart
+++ b/packages/quizzes/alarm/lib/src/presentation/quiz2_set_weekdays/set_weekdays_quiz_notifier.dart
@@ -7,7 +7,6 @@ import 'package:system/system.dart';
 
 import '../../application/quiz_set_weekdays_use_case.dart';
 import '../../domain/alarm_catalog.dart';
-import '../../domain/alarm_quiz_config.dart';
 import '../../infrastructure/alarm_quiz_repository_provider.dart';
 import 'set_weekdays_quiz_state.dart';
 
@@ -32,7 +31,6 @@ class SetWeekdaysQuizNotifier
     // Quiz2では最初にアラーム一覧を表示し、alarm_2（真ん中）をタップさせる
     return SetWeekdaysQuizState.initial(
       draft: AlarmCatalog.initialAlarms[1],
-      timeLimitSeconds: AlarmQuizConfig.quiz2SetWeekdaysTimeLimitSeconds,
     );
   }
 
@@ -41,7 +39,6 @@ class SetWeekdaysQuizNotifier
     _timer?.cancel();
     state = SetWeekdaysQuizState.initial(
       draft: AlarmCatalog.initialAlarms[1],
-      timeLimitSeconds: AlarmQuizConfig.quiz2SetWeekdaysTimeLimitSeconds,
     ).copyWith(
       status: QuizStatus.playing,
       startedAt: clock.now(),
@@ -147,7 +144,6 @@ class SetWeekdaysQuizNotifier
     final prevFailureCount = state.failureCount;
     state = SetWeekdaysQuizState.initial(
       draft: AlarmCatalog.initialAlarms[1],
-      timeLimitSeconds: AlarmQuizConfig.quiz2SetWeekdaysTimeLimitSeconds,
     ).copyWith(
       status: QuizStatus.playing,
       startedAt: clock.now(),

--- a/packages/quizzes/alarm/lib/src/presentation/quiz2_set_weekdays/set_weekdays_quiz_state.dart
+++ b/packages/quizzes/alarm/lib/src/presentation/quiz2_set_weekdays/set_weekdays_quiz_state.dart
@@ -1,5 +1,6 @@
 import 'package:quiz_core/quiz_core.dart';
 
+import '../../domain/alarm_quiz_config.dart';
 import '../../domain/entities/alarm_item.dart';
 
 /// Quiz 2「平日繰り返しを設定する」の状態
@@ -18,7 +19,6 @@ class SetWeekdaysQuizState extends QuizStateBase {
   /// 初期状態を生成する
   factory SetWeekdaysQuizState.initial({
     required AlarmItem draft,
-    int timeLimitSeconds = 45,
   }) =>
       SetWeekdaysQuizState(
         status: QuizStatus.idle,
@@ -26,7 +26,7 @@ class SetWeekdaysQuizState extends QuizStateBase {
         elapsedMs: 0,
         startedAt: null,
         draftAlarm: draft,
-        remainingSeconds: timeLimitSeconds,
+        remainingSeconds: AlarmQuizConfig.quiz2SetWeekdaysTimeLimitSeconds,
         showEditForm: false,
       );
 

--- a/packages/quizzes/alarm/lib/src/presentation/quiz3_disable_snooze/disable_snooze_quiz_notifier.dart
+++ b/packages/quizzes/alarm/lib/src/presentation/quiz3_disable_snooze/disable_snooze_quiz_notifier.dart
@@ -7,7 +7,6 @@ import 'package:system/system.dart';
 
 import '../../application/quiz_disable_snooze_use_case.dart';
 import '../../domain/alarm_catalog.dart';
-import '../../domain/alarm_quiz_config.dart';
 import '../../infrastructure/alarm_quiz_repository_provider.dart';
 import 'disable_snooze_quiz_state.dart';
 
@@ -31,7 +30,6 @@ class DisableSnoozeQuizNotifier
     ref.onDispose(() => _timer?.cancel());
     return DisableSnoozeQuizState.initial(
       alarm: AlarmCatalog.initialAlarms[0],
-      timeLimitSeconds: AlarmQuizConfig.quiz3DisableSnoozeTimeLimitSeconds,
     );
   }
 
@@ -40,7 +38,6 @@ class DisableSnoozeQuizNotifier
     _timer?.cancel();
     state = DisableSnoozeQuizState.initial(
       alarm: AlarmCatalog.initialAlarms[0],
-      timeLimitSeconds: AlarmQuizConfig.quiz3DisableSnoozeTimeLimitSeconds,
     ).copyWith(
       status: QuizStatus.playing,
       startedAt: clock.now(),
@@ -149,7 +146,6 @@ class DisableSnoozeQuizNotifier
     final prevFailureCount = state.failureCount;
     state = DisableSnoozeQuizState.initial(
       alarm: AlarmCatalog.initialAlarms[0],
-      timeLimitSeconds: AlarmQuizConfig.quiz3DisableSnoozeTimeLimitSeconds,
     ).copyWith(
       status: QuizStatus.playing,
       startedAt: clock.now(),

--- a/packages/quizzes/alarm/lib/src/presentation/quiz3_disable_snooze/disable_snooze_quiz_state.dart
+++ b/packages/quizzes/alarm/lib/src/presentation/quiz3_disable_snooze/disable_snooze_quiz_state.dart
@@ -1,5 +1,6 @@
 import 'package:quiz_core/quiz_core.dart';
 
+import '../../domain/alarm_quiz_config.dart';
 import '../../domain/entities/alarm_item.dart';
 
 /// Quiz 3「スヌーズをオフにする」の状態
@@ -19,7 +20,6 @@ class DisableSnoozeQuizState extends QuizStateBase {
   /// 初期状態を生成する
   factory DisableSnoozeQuizState.initial({
     required AlarmItem alarm,
-    int timeLimitSeconds = 60,
   }) =>
       DisableSnoozeQuizState(
         status: QuizStatus.idle,
@@ -28,7 +28,7 @@ class DisableSnoozeQuizState extends QuizStateBase {
         startedAt: null,
         draftAlarm: alarm,
         saved: false,
-        remainingSeconds: timeLimitSeconds,
+        remainingSeconds: AlarmQuizConfig.quiz3DisableSnoozeTimeLimitSeconds,
         showEditForm: false,
       );
 

--- a/packages/quizzes/alarm/lib/src/presentation/quiz4_delete_alarm/delete_alarm_quiz_notifier.dart
+++ b/packages/quizzes/alarm/lib/src/presentation/quiz4_delete_alarm/delete_alarm_quiz_notifier.dart
@@ -7,7 +7,6 @@ import 'package:system/system.dart';
 
 import '../../application/quiz_delete_alarm_use_case.dart';
 import '../../domain/alarm_catalog.dart';
-import '../../domain/alarm_quiz_config.dart';
 import '../../infrastructure/alarm_quiz_repository_provider.dart';
 import 'delete_alarm_quiz_state.dart';
 
@@ -30,7 +29,6 @@ class DeleteAlarmQuizNotifier
     ref.onDispose(() => _timer?.cancel());
     return DeleteAlarmQuizState.initial(
       alarms: AlarmCatalog.initialAlarms,
-      timeLimitSeconds: AlarmQuizConfig.quiz4DeleteAlarmTimeLimitSeconds,
     );
   }
 
@@ -39,7 +37,6 @@ class DeleteAlarmQuizNotifier
     _timer?.cancel();
     state = DeleteAlarmQuizState.initial(
       alarms: AlarmCatalog.initialAlarms,
-      timeLimitSeconds: AlarmQuizConfig.quiz4DeleteAlarmTimeLimitSeconds,
     ).copyWith(
       status: QuizStatus.playing,
       startedAt: clock.now(),
@@ -114,7 +111,6 @@ class DeleteAlarmQuizNotifier
     final prevFailureCount = state.failureCount;
     state = DeleteAlarmQuizState.initial(
       alarms: AlarmCatalog.initialAlarms,
-      timeLimitSeconds: AlarmQuizConfig.quiz4DeleteAlarmTimeLimitSeconds,
     ).copyWith(
       status: QuizStatus.playing,
       startedAt: clock.now(),

--- a/packages/quizzes/alarm/lib/src/presentation/quiz4_delete_alarm/delete_alarm_quiz_state.dart
+++ b/packages/quizzes/alarm/lib/src/presentation/quiz4_delete_alarm/delete_alarm_quiz_state.dart
@@ -1,5 +1,6 @@
 import 'package:quiz_core/quiz_core.dart';
 
+import '../../domain/alarm_quiz_config.dart';
 import '../../domain/entities/alarm_item.dart';
 
 /// Quiz 4「アラームを削除する」の状態
@@ -18,7 +19,6 @@ class DeleteAlarmQuizState extends QuizStateBase {
   /// 初期状態を生成する
   factory DeleteAlarmQuizState.initial({
     required List<AlarmItem> alarms,
-    int timeLimitSeconds = 45,
   }) =>
       DeleteAlarmQuizState(
         status: QuizStatus.idle,
@@ -27,7 +27,7 @@ class DeleteAlarmQuizState extends QuizStateBase {
         startedAt: null,
         alarms: alarms,
         deletedAlarmIds: const {},
-        remainingSeconds: timeLimitSeconds,
+        remainingSeconds: AlarmQuizConfig.quiz4DeleteAlarmTimeLimitSeconds,
       );
 
   /// 表示中のアラームリスト

--- a/packages/quizzes/chat/lib/src/presentation/quiz1_send_message/send_message_quiz_notifier.dart
+++ b/packages/quizzes/chat/lib/src/presentation/quiz1_send_message/send_message_quiz_notifier.dart
@@ -28,7 +28,6 @@ class SendMessageQuizNotifier
     ref.onDispose(() => _timer?.cancel());
     return SendMessageQuizState.initial(
       initialMessages: ChatCatalog.quiz1InitialMessages(clock.now()),
-      timeLimitSeconds: ChatQuizConfig.quiz1SendMessageTimeLimitSeconds,
     );
   }
 
@@ -107,7 +106,6 @@ class SendMessageQuizNotifier
     ref.read(analyticsServiceProvider).logQuizRetried(quizId: _quizId);
     state = SendMessageQuizState.initial(
       initialMessages: ChatCatalog.quiz1InitialMessages(clock.now()),
-      timeLimitSeconds: ChatQuizConfig.quiz1SendMessageTimeLimitSeconds,
     ).copyWith(
       status: QuizStatus.playing,
       startedAt: clock.now(),

--- a/packages/quizzes/chat/lib/src/presentation/quiz1_send_message/send_message_quiz_state.dart
+++ b/packages/quizzes/chat/lib/src/presentation/quiz1_send_message/send_message_quiz_state.dart
@@ -1,3 +1,4 @@
+import 'package:chat/src/domain/chat_quiz_config.dart';
 import 'package:chat/src/domain/entities/chat_message.dart';
 import 'package:quiz_core/quiz_core.dart';
 
@@ -38,7 +39,6 @@ class SendMessageQuizState extends QuizStateBase {
 
   factory SendMessageQuizState.initial({
     required List<ChatMessage> initialMessages,
-    int timeLimitSeconds = 60,
   }) =>
       SendMessageQuizState(
         status: QuizStatus.idle,
@@ -47,6 +47,6 @@ class SendMessageQuizState extends QuizStateBase {
         startedAt: null,
         messages: initialMessages,
         inputText: '',
-        remainingSeconds: timeLimitSeconds,
+        remainingSeconds: ChatQuizConfig.quiz1SendMessageTimeLimitSeconds,
       );
 }

--- a/packages/quizzes/chat/lib/src/presentation/quiz1_send_stamp/send_stamp_quiz_notifier.dart
+++ b/packages/quizzes/chat/lib/src/presentation/quiz1_send_stamp/send_stamp_quiz_notifier.dart
@@ -28,7 +28,6 @@ class SendStampQuizNotifier extends AutoDisposeNotifier<SendStampQuizState> {
     ref.onDispose(() => _timer?.cancel());
     return SendStampQuizState.initial(
       initialMessages: ChatCatalog.quiz1InitialMessages(clock.now()),
-      timeLimitSeconds: ChatQuizConfig.quiz1SendStampTimeLimitSeconds,
     );
   }
 
@@ -187,7 +186,6 @@ class SendStampQuizNotifier extends AutoDisposeNotifier<SendStampQuizState> {
     ref.read(analyticsServiceProvider).logQuizRetried(quizId: _quizId);
     state = SendStampQuizState.initial(
       initialMessages: ChatCatalog.quiz1InitialMessages(clock.now()),
-      timeLimitSeconds: ChatQuizConfig.quiz1SendStampTimeLimitSeconds,
     ).copyWith(
       status: QuizStatus.playing,
       startedAt: clock.now(),

--- a/packages/quizzes/chat/lib/src/presentation/quiz1_send_stamp/send_stamp_quiz_state.dart
+++ b/packages/quizzes/chat/lib/src/presentation/quiz1_send_stamp/send_stamp_quiz_state.dart
@@ -1,3 +1,4 @@
+import 'package:chat/src/domain/chat_quiz_config.dart';
 import 'package:chat/src/domain/chat_tab.dart';
 import 'package:chat/src/domain/entities/chat_message.dart';
 import 'package:quiz_core/quiz_core.dart';
@@ -54,7 +55,6 @@ class SendStampQuizState extends QuizStateBase {
 
   factory SendStampQuizState.initial({
     required List<ChatMessage> initialMessages,
-    int timeLimitSeconds = 30,
   }) =>
       SendStampQuizState(
         status: QuizStatus.idle,
@@ -64,7 +64,7 @@ class SendStampQuizState extends QuizStateBase {
         currentTab: ChatTab.home,
         isInChatRoom: false,
         messages: initialMessages,
-        remainingSeconds: timeLimitSeconds,
+        remainingSeconds: ChatQuizConfig.quiz1SendStampTimeLimitSeconds,
         isCorrectChatRoom: true,
       );
 }

--- a/packages/quizzes/chat/lib/src/presentation/quiz2_reaction/reaction_quiz_notifier.dart
+++ b/packages/quizzes/chat/lib/src/presentation/quiz2_reaction/reaction_quiz_notifier.dart
@@ -28,7 +28,6 @@ class ReactionQuizNotifier extends AutoDisposeNotifier<ReactionQuizState> {
     ref.onDispose(() => _timer?.cancel());
     return ReactionQuizState.initial(
       initialMessages: ChatCatalog.quiz2InitialMessages(clock.now()),
-      timeLimitSeconds: ChatQuizConfig.quiz2ReactionTimeLimitSeconds,
     );
   }
 
@@ -204,7 +203,6 @@ class ReactionQuizNotifier extends AutoDisposeNotifier<ReactionQuizState> {
     ref.read(analyticsServiceProvider).logQuizRetried(quizId: _quizId);
     state = ReactionQuizState.initial(
       initialMessages: ChatCatalog.quiz2InitialMessages(clock.now()),
-      timeLimitSeconds: ChatQuizConfig.quiz2ReactionTimeLimitSeconds,
     ).copyWith(
       status: QuizStatus.playing,
       startedAt: clock.now(),

--- a/packages/quizzes/chat/lib/src/presentation/quiz2_reaction/reaction_quiz_state.dart
+++ b/packages/quizzes/chat/lib/src/presentation/quiz2_reaction/reaction_quiz_state.dart
@@ -1,3 +1,4 @@
+import 'package:chat/src/domain/chat_quiz_config.dart';
 import 'package:chat/src/domain/chat_tab.dart';
 import 'package:chat/src/domain/entities/chat_message.dart';
 import 'package:quiz_core/quiz_core.dart';
@@ -59,7 +60,6 @@ class ReactionQuizState extends QuizStateBase {
 
   factory ReactionQuizState.initial({
     required List<ChatMessage> initialMessages,
-    int timeLimitSeconds = 45,
   }) =>
       ReactionQuizState(
         status: QuizStatus.idle,
@@ -69,7 +69,7 @@ class ReactionQuizState extends QuizStateBase {
         currentTab: ChatTab.home,
         isInChatRoom: false,
         messages: initialMessages,
-        remainingSeconds: timeLimitSeconds,
+        remainingSeconds: ChatQuizConfig.quiz2ReactionTimeLimitSeconds,
         isCorrectChatRoom: true,
       );
 }

--- a/packages/quizzes/chat/lib/src/presentation/quiz2_send_stamp/send_stamp_quiz_notifier.dart
+++ b/packages/quizzes/chat/lib/src/presentation/quiz2_send_stamp/send_stamp_quiz_notifier.dart
@@ -27,7 +27,6 @@ class SendStampQuizNotifier extends AutoDisposeNotifier<SendStampQuizState> {
     ref.onDispose(() => _timer?.cancel());
     return SendStampQuizState.initial(
       initialMessages: ChatCatalog.quiz2InitialMessages(clock.now()),
-      timeLimitSeconds: ChatQuizConfig.quiz2SendStampTimeLimitSeconds,
     );
   }
 
@@ -110,7 +109,6 @@ class SendStampQuizNotifier extends AutoDisposeNotifier<SendStampQuizState> {
     ref.read(analyticsServiceProvider).logQuizRetried(quizId: _quizId);
     state = SendStampQuizState.initial(
       initialMessages: ChatCatalog.quiz2InitialMessages(clock.now()),
-      timeLimitSeconds: ChatQuizConfig.quiz2SendStampTimeLimitSeconds,
     ).copyWith(
       status: QuizStatus.playing,
       startedAt: clock.now(),

--- a/packages/quizzes/chat/lib/src/presentation/quiz2_send_stamp/send_stamp_quiz_state.dart
+++ b/packages/quizzes/chat/lib/src/presentation/quiz2_send_stamp/send_stamp_quiz_state.dart
@@ -1,3 +1,4 @@
+import 'package:chat/src/domain/chat_quiz_config.dart';
 import 'package:chat/src/domain/entities/chat_message.dart';
 import 'package:quiz_core/quiz_core.dart';
 
@@ -38,7 +39,6 @@ class SendStampQuizState extends QuizStateBase {
 
   factory SendStampQuizState.initial({
     required List<ChatMessage> initialMessages,
-    int timeLimitSeconds = 60,
   }) =>
       SendStampQuizState(
         status: QuizStatus.idle,
@@ -46,6 +46,6 @@ class SendStampQuizState extends QuizStateBase {
         elapsedMs: 0,
         startedAt: null,
         messages: initialMessages,
-        remainingSeconds: timeLimitSeconds,
+        remainingSeconds: ChatQuizConfig.quiz2SendStampTimeLimitSeconds,
       );
 }

--- a/packages/quizzes/chat/lib/src/presentation/quiz3_delete_message/delete_message_quiz_notifier.dart
+++ b/packages/quizzes/chat/lib/src/presentation/quiz3_delete_message/delete_message_quiz_notifier.dart
@@ -27,7 +27,6 @@ class DeleteMessageQuizNotifier
     ref.onDispose(() => _timer?.cancel());
     return DeleteMessageQuizState.initial(
       initialMessages: ChatCatalog.quiz3InitialMessages(clock.now()),
-      timeLimitSeconds: ChatQuizConfig.quiz3DeleteMessageTimeLimitSeconds,
     );
   }
 
@@ -95,7 +94,6 @@ class DeleteMessageQuizNotifier
     ref.read(analyticsServiceProvider).logQuizRetried(quizId: _quizId);
     state = DeleteMessageQuizState.initial(
       initialMessages: ChatCatalog.quiz3InitialMessages(clock.now()),
-      timeLimitSeconds: ChatQuizConfig.quiz3DeleteMessageTimeLimitSeconds,
     ).copyWith(
       status: QuizStatus.playing,
       startedAt: clock.now(),

--- a/packages/quizzes/chat/lib/src/presentation/quiz3_delete_message/delete_message_quiz_state.dart
+++ b/packages/quizzes/chat/lib/src/presentation/quiz3_delete_message/delete_message_quiz_state.dart
@@ -1,3 +1,4 @@
+import 'package:chat/src/domain/chat_quiz_config.dart';
 import 'package:chat/src/domain/entities/chat_message.dart';
 import 'package:quiz_core/quiz_core.dart';
 
@@ -38,7 +39,6 @@ class DeleteMessageQuizState extends QuizStateBase {
 
   factory DeleteMessageQuizState.initial({
     required List<ChatMessage> initialMessages,
-    int timeLimitSeconds = 90,
   }) =>
       DeleteMessageQuizState(
         status: QuizStatus.idle,
@@ -46,7 +46,7 @@ class DeleteMessageQuizState extends QuizStateBase {
         elapsedMs: 0,
         startedAt: null,
         messages: initialMessages,
-        remainingSeconds: timeLimitSeconds,
+        remainingSeconds: ChatQuizConfig.quiz3DeleteMessageTimeLimitSeconds,
         messageDeleted: false,
       );
 }

--- a/packages/quizzes/chat/lib/src/presentation/quiz3_send_image/send_image_quiz_notifier.dart
+++ b/packages/quizzes/chat/lib/src/presentation/quiz3_send_image/send_image_quiz_notifier.dart
@@ -29,7 +29,6 @@ class SendImageQuizNotifier extends AutoDisposeNotifier<SendImageQuizState> {
     ref.onDispose(() => _timer?.cancel());
     return SendImageQuizState.initial(
       initialMessages: ChatCatalog.quiz3InitialMessages(clock.now()),
-      timeLimitSeconds: ChatQuizConfig.quiz3SendImageTimeLimitSeconds,
     );
   }
 
@@ -177,7 +176,6 @@ class SendImageQuizNotifier extends AutoDisposeNotifier<SendImageQuizState> {
     ref.read(analyticsServiceProvider).logQuizRetried(quizId: _quizId);
     state = SendImageQuizState.initial(
       initialMessages: ChatCatalog.quiz3InitialMessages(clock.now()),
-      timeLimitSeconds: ChatQuizConfig.quiz3SendImageTimeLimitSeconds,
     ).copyWith(
       status: QuizStatus.playing,
     );

--- a/packages/quizzes/chat/lib/src/presentation/quiz3_send_image/send_image_quiz_state.dart
+++ b/packages/quizzes/chat/lib/src/presentation/quiz3_send_image/send_image_quiz_state.dart
@@ -1,3 +1,4 @@
+import 'package:chat/src/domain/chat_quiz_config.dart';
 import 'package:chat/src/domain/chat_tab.dart';
 import 'package:chat/src/domain/entities/chat_contact.dart';
 import 'package:chat/src/domain/entities/chat_message.dart';
@@ -57,7 +58,6 @@ class SendImageQuizState extends QuizStateBase {
 
   factory SendImageQuizState.initial({
     required List<ChatMessage> initialMessages,
-    int timeLimitSeconds = 60,
   }) =>
       SendImageQuizState(
         status: QuizStatus.idle,
@@ -67,6 +67,6 @@ class SendImageQuizState extends QuizStateBase {
         currentTab: ChatTab.home,
         isInChatRoom: false,
         messages: initialMessages,
-        remainingSeconds: timeLimitSeconds,
+        remainingSeconds: ChatQuizConfig.quiz3SendImageTimeLimitSeconds,
       );
 }

--- a/packages/quizzes/chat/lib/src/presentation/quiz4_cancel_message/cancel_message_quiz_notifier.dart
+++ b/packages/quizzes/chat/lib/src/presentation/quiz4_cancel_message/cancel_message_quiz_notifier.dart
@@ -28,7 +28,6 @@ class CancelMessageQuizNotifier
     ref.onDispose(() => _timer?.cancel());
     return CancelMessageQuizState.initial(
       initialMessages: ChatCatalog.quiz4InitialMessages(clock.now()),
-      timeLimitSeconds: ChatQuizConfig.quiz4CancelMessageTimeLimitSeconds,
     );
   }
 
@@ -129,7 +128,6 @@ class CancelMessageQuizNotifier
     ref.read(analyticsServiceProvider).logQuizRetried(quizId: _quizId);
     state = CancelMessageQuizState.initial(
       initialMessages: ChatCatalog.quiz4InitialMessages(clock.now()),
-      timeLimitSeconds: ChatQuizConfig.quiz4CancelMessageTimeLimitSeconds,
     ).copyWith(
       status: QuizStatus.playing,
       startedAt: clock.now(),

--- a/packages/quizzes/chat/lib/src/presentation/quiz4_cancel_message/cancel_message_quiz_state.dart
+++ b/packages/quizzes/chat/lib/src/presentation/quiz4_cancel_message/cancel_message_quiz_state.dart
@@ -1,3 +1,4 @@
+import 'package:chat/src/domain/chat_quiz_config.dart';
 import 'package:chat/src/domain/chat_tab.dart';
 import 'package:chat/src/domain/entities/chat_message.dart';
 import 'package:quiz_core/quiz_core.dart';
@@ -56,7 +57,6 @@ class CancelMessageQuizState extends QuizStateBase {
 
   factory CancelMessageQuizState.initial({
     required List<ChatMessage> initialMessages,
-    int timeLimitSeconds = 60,
   }) =>
       CancelMessageQuizState(
         status: QuizStatus.idle,
@@ -66,7 +66,7 @@ class CancelMessageQuizState extends QuizStateBase {
         currentTab: ChatTab.home,
         isInChatRoom: false,
         messages: initialMessages,
-        remainingSeconds: timeLimitSeconds,
+        remainingSeconds: ChatQuizConfig.quiz4CancelMessageTimeLimitSeconds,
         messageCancelled: false,
         isCorrectChatRoom: true,
       );

--- a/packages/quizzes/chat/lib/src/presentation/quiz4_create_group/create_group_quiz_notifier.dart
+++ b/packages/quizzes/chat/lib/src/presentation/quiz4_create_group/create_group_quiz_notifier.dart
@@ -26,7 +26,7 @@ class CreateGroupQuizNotifier
   @override
   CreateGroupQuizState build() {
     ref.onDispose(() => _timer?.cancel());
-    return CreateGroupQuizState.initial(timeLimitSeconds: ChatQuizConfig.quiz4CreateGroupTimeLimitSeconds);
+    return CreateGroupQuizState.initial();
   }
 
   void startQuiz() {
@@ -122,9 +122,7 @@ class CreateGroupQuizNotifier
   void retry() {
     _timer?.cancel();
     ref.read(analyticsServiceProvider).logQuizRetried(quizId: _quizId);
-    state = CreateGroupQuizState.initial(
-      timeLimitSeconds: ChatQuizConfig.quiz4CreateGroupTimeLimitSeconds,
-    ).copyWith(
+    state = CreateGroupQuizState.initial().copyWith(
       status: QuizStatus.playing,
       startedAt: clock.now(),
     );

--- a/packages/quizzes/chat/lib/src/presentation/quiz4_create_group/create_group_quiz_state.dart
+++ b/packages/quizzes/chat/lib/src/presentation/quiz4_create_group/create_group_quiz_state.dart
@@ -1,3 +1,4 @@
+import 'package:chat/src/domain/chat_quiz_config.dart';
 import 'package:chat/src/domain/entities/chat_contact.dart';
 import 'package:quiz_core/quiz_core.dart';
 
@@ -55,13 +56,13 @@ class CreateGroupQuizState extends QuizStateBase {
     );
   }
 
-  factory CreateGroupQuizState.initial({int timeLimitSeconds = 120}) =>
+  factory CreateGroupQuizState.initial() =>
       CreateGroupQuizState(
         status: QuizStatus.idle,
         failureCount: 0,
         elapsedMs: 0,
         startedAt: null,
-        remainingSeconds: timeLimitSeconds,
+        remainingSeconds: ChatQuizConfig.quiz4CreateGroupTimeLimitSeconds,
         step: CreateGroupStep.contactList,
         selectedMembers: const [],
         groupCreated: false,

--- a/packages/quizzes/map/lib/src/presentation/quiz1_show_location/show_location_quiz_notifier.dart
+++ b/packages/quizzes/map/lib/src/presentation/quiz1_show_location/show_location_quiz_notifier.dart
@@ -6,7 +6,6 @@ import 'package:quiz_core/quiz_core.dart';
 import 'package:system/system.dart';
 
 import '../../application/quiz_show_location_use_case.dart';
-import '../../domain/map_quiz_config.dart';
 import '../../infrastructure/map_quiz_repository_provider.dart';
 import 'show_location_quiz_state.dart';
 
@@ -26,15 +25,13 @@ class ShowLocationQuizNotifier
   @override
   ShowLocationQuizState build() {
     ref.onDispose(() => _timer?.cancel());
-    return ShowLocationQuizState.initial(timeLimitSeconds: MapQuizConfig.quiz1ShowLocationTimeLimitSeconds);
+    return ShowLocationQuizState.initial();
   }
 
   /// クイズを開始する
   void startQuiz() {
     _timer?.cancel();
-    state = ShowLocationQuizState.initial(
-      timeLimitSeconds: MapQuizConfig.quiz1ShowLocationTimeLimitSeconds,
-    ).copyWith(
+    state = ShowLocationQuizState.initial().copyWith(
       status: QuizStatus.playing,
       startedAt: clock.now(),
     );
@@ -82,9 +79,7 @@ class ShowLocationQuizNotifier
   void retry() {
     _timer?.cancel();
     ref.read(analyticsServiceProvider).logQuizRetried(quizId: _quizId);
-    state = ShowLocationQuizState.initial(
-      timeLimitSeconds: MapQuizConfig.quiz1ShowLocationTimeLimitSeconds,
-    ).copyWith(
+    state = ShowLocationQuizState.initial().copyWith(
       status: QuizStatus.playing,
       startedAt: clock.now(),
     );

--- a/packages/quizzes/map/lib/src/presentation/quiz1_show_location/show_location_quiz_state.dart
+++ b/packages/quizzes/map/lib/src/presentation/quiz1_show_location/show_location_quiz_state.dart
@@ -1,5 +1,7 @@
 import 'package:quiz_core/quiz_core.dart';
 
+import '../../domain/map_quiz_config.dart';
+
 /// Quiz 1「現在地を表示する」の状態
 class ShowLocationQuizState extends QuizStateBase {
   /// コンストラクタ
@@ -13,14 +15,14 @@ class ShowLocationQuizState extends QuizStateBase {
   });
 
   /// 初期状態を生成する
-  factory ShowLocationQuizState.initial({int timeLimitSeconds = 60}) =>
+  factory ShowLocationQuizState.initial() =>
       ShowLocationQuizState(
         status: QuizStatus.idle,
         failureCount: 0,
         elapsedMs: 0,
         startedAt: null,
         locationShown: false,
-        remainingSeconds: timeLimitSeconds,
+        remainingSeconds: MapQuizConfig.quiz1ShowLocationTimeLimitSeconds,
       );
 
   /// 現在地が表示されているかどうか

--- a/packages/quizzes/map/lib/src/presentation/quiz2_search_place/search_place_quiz_notifier.dart
+++ b/packages/quizzes/map/lib/src/presentation/quiz2_search_place/search_place_quiz_notifier.dart
@@ -7,7 +7,6 @@ import 'package:system/system.dart';
 
 import '../../application/quiz_search_place_use_case.dart';
 import '../../domain/entities/map_place.dart';
-import '../../domain/map_quiz_config.dart';
 import '../../infrastructure/map_quiz_repository_provider.dart';
 import 'search_place_quiz_state.dart';
 
@@ -27,15 +26,13 @@ class ShowSchoolInfoQuizNotifier
   @override
   ShowSchoolInfoQuizState build() {
     ref.onDispose(() => _timer?.cancel());
-    return ShowSchoolInfoQuizState.initial(timeLimitSeconds: MapQuizConfig.quiz2SearchPlaceTimeLimitSeconds);
+    return ShowSchoolInfoQuizState.initial();
   }
 
   /// クイズを開始する
   void startQuiz() {
     _timer?.cancel();
-    state = ShowSchoolInfoQuizState.initial(
-      timeLimitSeconds: MapQuizConfig.quiz2SearchPlaceTimeLimitSeconds,
-    ).copyWith(
+    state = ShowSchoolInfoQuizState.initial().copyWith(
       status: QuizStatus.playing,
       startedAt: clock.now(),
     );
@@ -92,9 +89,7 @@ class ShowSchoolInfoQuizNotifier
   void retry() {
     _timer?.cancel();
     ref.read(analyticsServiceProvider).logQuizRetried(quizId: _quizId);
-    state = ShowSchoolInfoQuizState.initial(
-      timeLimitSeconds: MapQuizConfig.quiz2SearchPlaceTimeLimitSeconds,
-    ).copyWith(
+    state = ShowSchoolInfoQuizState.initial().copyWith(
       status: QuizStatus.playing,
       startedAt: clock.now(),
     );

--- a/packages/quizzes/map/lib/src/presentation/quiz2_search_place/search_place_quiz_state.dart
+++ b/packages/quizzes/map/lib/src/presentation/quiz2_search_place/search_place_quiz_state.dart
@@ -1,6 +1,7 @@
 import 'package:quiz_core/quiz_core.dart';
 
 import '../../domain/entities/map_place.dart';
+import '../../domain/map_quiz_config.dart';
 
 /// Quiz 2「学校の情報を表示する」の状態
 class ShowSchoolInfoQuizState extends QuizStateBase {
@@ -15,14 +16,14 @@ class ShowSchoolInfoQuizState extends QuizStateBase {
   });
 
   /// 初期状態を生成する
-  factory ShowSchoolInfoQuizState.initial({int timeLimitSeconds = 60}) =>
+  factory ShowSchoolInfoQuizState.initial() =>
       ShowSchoolInfoQuizState(
         status: QuizStatus.idle,
         failureCount: 0,
         elapsedMs: 0,
         startedAt: null,
         selectedPlace: null,
-        remainingSeconds: timeLimitSeconds,
+        remainingSeconds: MapQuizConfig.quiz2SearchPlaceTimeLimitSeconds,
       );
 
   /// 選択された場所（クリア時のみセット）

--- a/packages/quizzes/map/lib/src/presentation/quiz3_start_navigation/start_navigation_quiz_notifier.dart
+++ b/packages/quizzes/map/lib/src/presentation/quiz3_start_navigation/start_navigation_quiz_notifier.dart
@@ -7,7 +7,6 @@ import 'package:system/system.dart';
 
 import '../../application/quiz_start_navigation_use_case.dart';
 import '../../domain/entities/map_place.dart';
-import '../../domain/map_quiz_config.dart';
 import '../../infrastructure/map_quiz_repository_provider.dart';
 import 'start_navigation_quiz_state.dart';
 
@@ -27,15 +26,13 @@ class StartNavigationQuizNotifier
   @override
   StartNavigationQuizState build() {
     ref.onDispose(() => _timer?.cancel());
-    return StartNavigationQuizState.initial(timeLimitSeconds: MapQuizConfig.quiz3StartNavigationTimeLimitSeconds);
+    return StartNavigationQuizState.initial();
   }
 
   /// クイズを開始する
   void startQuiz() {
     _timer?.cancel();
-    state = StartNavigationQuizState.initial(
-      timeLimitSeconds: MapQuizConfig.quiz3StartNavigationTimeLimitSeconds,
-    ).copyWith(
+    state = StartNavigationQuizState.initial().copyWith(
       status: QuizStatus.playing,
       startedAt: clock.now(),
     );
@@ -120,9 +117,7 @@ class StartNavigationQuizNotifier
   void retry() {
     _timer?.cancel();
     ref.read(analyticsServiceProvider).logQuizRetried(quizId: _quizId);
-    state = StartNavigationQuizState.initial(
-      timeLimitSeconds: MapQuizConfig.quiz3StartNavigationTimeLimitSeconds,
-    ).copyWith(
+    state = StartNavigationQuizState.initial().copyWith(
       status: QuizStatus.playing,
       startedAt: clock.now(),
     );

--- a/packages/quizzes/map/lib/src/presentation/quiz3_start_navigation/start_navigation_quiz_state.dart
+++ b/packages/quizzes/map/lib/src/presentation/quiz3_start_navigation/start_navigation_quiz_state.dart
@@ -1,6 +1,7 @@
 import 'package:quiz_core/quiz_core.dart';
 
 import '../../domain/entities/map_place.dart';
+import '../../domain/map_quiz_config.dart';
 
 /// Quiz 3「目的地と交通手段を選んでルートを案内する」の状態
 class StartNavigationQuizState extends QuizStateBase {
@@ -18,7 +19,7 @@ class StartNavigationQuizState extends QuizStateBase {
   });
 
   /// 初期状態を生成する（目的地・交通手段ともに未選択）
-  factory StartNavigationQuizState.initial({int timeLimitSeconds = 60}) =>
+  factory StartNavigationQuizState.initial() =>
       StartNavigationQuizState(
         status: QuizStatus.idle,
         failureCount: 0,
@@ -28,7 +29,7 @@ class StartNavigationQuizState extends QuizStateBase {
         showDirections: false,
         selectedTransportIndex: null,
         navigationStarted: false,
-        remainingSeconds: timeLimitSeconds,
+        remainingSeconds: MapQuizConfig.quiz3StartNavigationTimeLimitSeconds,
       );
 
   /// 選択された目的地

--- a/packages/quizzes/map/lib/src/presentation/quiz4_save_place/save_place_quiz_notifier.dart
+++ b/packages/quizzes/map/lib/src/presentation/quiz4_save_place/save_place_quiz_notifier.dart
@@ -7,7 +7,6 @@ import 'package:system/system.dart';
 
 import '../../application/quiz_save_place_use_case.dart';
 import '../../domain/entities/map_place.dart';
-import '../../domain/map_quiz_config.dart';
 import '../../infrastructure/map_quiz_repository_provider.dart';
 import 'save_place_quiz_state.dart';
 
@@ -26,15 +25,13 @@ class SavePlaceQuizNotifier extends AutoDisposeNotifier<SavePlaceQuizState> {
   @override
   SavePlaceQuizState build() {
     ref.onDispose(() => _timer?.cancel());
-    return SavePlaceQuizState.initial(timeLimitSeconds: MapQuizConfig.quiz4SavePlaceTimeLimitSeconds);
+    return SavePlaceQuizState.initial();
   }
 
   /// クイズを開始する
   void startQuiz() {
     _timer?.cancel();
-    state = SavePlaceQuizState.initial(
-      timeLimitSeconds: MapQuizConfig.quiz4SavePlaceTimeLimitSeconds,
-    ).copyWith(
+    state = SavePlaceQuizState.initial().copyWith(
       status: QuizStatus.playing,
       startedAt: clock.now(),
     );
@@ -108,9 +105,7 @@ class SavePlaceQuizNotifier extends AutoDisposeNotifier<SavePlaceQuizState> {
   void retry() {
     _timer?.cancel();
     ref.read(analyticsServiceProvider).logQuizRetried(quizId: _quizId);
-    state = SavePlaceQuizState.initial(
-      timeLimitSeconds: MapQuizConfig.quiz4SavePlaceTimeLimitSeconds,
-    ).copyWith(
+    state = SavePlaceQuizState.initial().copyWith(
       status: QuizStatus.playing,
       startedAt: clock.now(),
     );

--- a/packages/quizzes/map/lib/src/presentation/quiz4_save_place/save_place_quiz_state.dart
+++ b/packages/quizzes/map/lib/src/presentation/quiz4_save_place/save_place_quiz_state.dart
@@ -1,6 +1,7 @@
 import 'package:quiz_core/quiz_core.dart';
 
 import '../../domain/entities/map_place.dart';
+import '../../domain/map_quiz_config.dart';
 
 /// Quiz 4「指定した場所をお気に入りに追加する」の状態
 class SavePlaceQuizState extends QuizStateBase {
@@ -15,14 +16,14 @@ class SavePlaceQuizState extends QuizStateBase {
   });
 
   /// 初期状態を生成する（場所は未選択）
-  factory SavePlaceQuizState.initial({int timeLimitSeconds = 60}) =>
+  factory SavePlaceQuizState.initial() =>
       SavePlaceQuizState(
         status: QuizStatus.idle,
         failureCount: 0,
         elapsedMs: 0,
         startedAt: null,
         selectedPlace: null,
-        remainingSeconds: timeLimitSeconds,
+        remainingSeconds: MapQuizConfig.quiz4SavePlaceTimeLimitSeconds,
       );
 
   /// 選択された場所（未選択の場合は null）

--- a/packages/quizzes/payment/lib/src/presentation/quiz1_show_qr/show_qr_quiz_notifier.dart
+++ b/packages/quizzes/payment/lib/src/presentation/quiz1_show_qr/show_qr_quiz_notifier.dart
@@ -6,7 +6,6 @@ import 'package:quiz_core/quiz_core.dart';
 import 'package:system/system.dart';
 
 import '../../application/quiz_show_qr_use_case.dart';
-import '../../domain/payment_quiz_config.dart';
 import '../../infrastructure/payment_quiz_repository_provider.dart';
 import 'show_qr_quiz_state.dart';
 
@@ -26,13 +25,13 @@ class ShowQrQuizNotifier extends AutoDisposeNotifier<ShowQrQuizState> {
   @override
   ShowQrQuizState build() {
     ref.onDispose(() => _timer?.cancel());
-    return ShowQrQuizState.initial(timeLimitSeconds: PaymentQuizConfig.quiz1ShowQrTimeLimitSeconds);
+    return ShowQrQuizState.initial();
   }
 
   /// クイズを開始する
   void startQuiz() {
     _timer?.cancel();
-    state = ShowQrQuizState.initial(timeLimitSeconds: PaymentQuizConfig.quiz1ShowQrTimeLimitSeconds)
+    state = ShowQrQuizState.initial()
         .copyWith(
       status: QuizStatus.playing,
       startedAt: clock.now(),
@@ -98,7 +97,7 @@ class ShowQrQuizNotifier extends AutoDisposeNotifier<ShowQrQuizState> {
   void retry() {
     _timer?.cancel();
     ref.read(analyticsServiceProvider).logQuizRetried(quizId: _quizId);
-    state = ShowQrQuizState.initial(timeLimitSeconds: PaymentQuizConfig.quiz1ShowQrTimeLimitSeconds)
+    state = ShowQrQuizState.initial()
         .copyWith(
       status: QuizStatus.playing,
       startedAt: clock.now(),

--- a/packages/quizzes/payment/lib/src/presentation/quiz1_show_qr/show_qr_quiz_state.dart
+++ b/packages/quizzes/payment/lib/src/presentation/quiz1_show_qr/show_qr_quiz_state.dart
@@ -1,5 +1,7 @@
 import 'package:quiz_core/quiz_core.dart';
 
+import '../../domain/payment_quiz_config.dart';
+
 /// Quiz 1「QRコードを表示する」の状態
 class ShowQrQuizState extends QuizStateBase {
   /// コンストラクタ
@@ -14,14 +16,14 @@ class ShowQrQuizState extends QuizStateBase {
   });
 
   /// 初期状態を生成する
-  factory ShowQrQuizState.initial({int timeLimitSeconds = 30}) =>
+  factory ShowQrQuizState.initial() =>
       ShowQrQuizState(
         status: QuizStatus.idle,
         failureCount: 0,
         elapsedMs: 0,
         startedAt: null,
         paymentShown: false,
-        remainingSeconds: timeLimitSeconds,
+        remainingSeconds: PaymentQuizConfig.quiz1ShowQrTimeLimitSeconds,
         hintUsed: false,
       );
 

--- a/packages/quizzes/payment/lib/src/presentation/quiz2_reveal_balance/reveal_balance_quiz_notifier.dart
+++ b/packages/quizzes/payment/lib/src/presentation/quiz2_reveal_balance/reveal_balance_quiz_notifier.dart
@@ -6,7 +6,6 @@ import 'package:quiz_core/quiz_core.dart';
 import 'package:system/system.dart';
 
 import '../../application/quiz_reveal_balance_use_case.dart';
-import '../../domain/payment_quiz_config.dart';
 import '../../infrastructure/payment_quiz_repository_provider.dart';
 import 'reveal_balance_quiz_state.dart';
 
@@ -27,14 +26,14 @@ class RevealBalanceQuizNotifier
   @override
   RevealBalanceQuizState build() {
     ref.onDispose(() => _timer?.cancel());
-    return RevealBalanceQuizState.initial(timeLimitSeconds: PaymentQuizConfig.quiz2RevealBalanceTimeLimitSeconds);
+    return RevealBalanceQuizState.initial();
   }
 
   /// クイズを開始する
   void startQuiz() {
     _timer?.cancel();
     state =
-        RevealBalanceQuizState.initial(timeLimitSeconds: PaymentQuizConfig.quiz2RevealBalanceTimeLimitSeconds)
+        RevealBalanceQuizState.initial()
             .copyWith(
       status: QuizStatus.playing,
       startedAt: clock.now(),
@@ -97,7 +96,7 @@ class RevealBalanceQuizNotifier
     _timer?.cancel();
     ref.read(analyticsServiceProvider).logQuizRetried(quizId: _quizId);
     state =
-        RevealBalanceQuizState.initial(timeLimitSeconds: PaymentQuizConfig.quiz2RevealBalanceTimeLimitSeconds)
+        RevealBalanceQuizState.initial()
             .copyWith(
       status: QuizStatus.playing,
       startedAt: clock.now(),

--- a/packages/quizzes/payment/lib/src/presentation/quiz2_reveal_balance/reveal_balance_quiz_state.dart
+++ b/packages/quizzes/payment/lib/src/presentation/quiz2_reveal_balance/reveal_balance_quiz_state.dart
@@ -1,5 +1,7 @@
 import 'package:quiz_core/quiz_core.dart';
 
+import '../../domain/payment_quiz_config.dart';
+
 /// Quiz 2「残高を隠す」の状態
 class RevealBalanceQuizState extends QuizStateBase {
   /// コンストラクタ
@@ -14,7 +16,7 @@ class RevealBalanceQuizState extends QuizStateBase {
   });
 
   /// 初期状態を生成する
-  factory RevealBalanceQuizState.initial({int timeLimitSeconds = 45}) =>
+  factory RevealBalanceQuizState.initial() =>
       RevealBalanceQuizState(
         status: QuizStatus.idle,
         failureCount: 0,
@@ -22,7 +24,7 @@ class RevealBalanceQuizState extends QuizStateBase {
         startedAt: null,
         // 初期状態: 残高は見えている（非表示フラグ = false）
         balanceHidden: false,
-        remainingSeconds: timeLimitSeconds,
+        remainingSeconds: PaymentQuizConfig.quiz2RevealBalanceTimeLimitSeconds,
         hintUsed: false,
       );
 

--- a/packages/quizzes/payment/lib/src/presentation/quiz3_send_money/send_money_quiz_notifier.dart
+++ b/packages/quizzes/payment/lib/src/presentation/quiz3_send_money/send_money_quiz_notifier.dart
@@ -6,7 +6,6 @@ import 'package:quiz_core/quiz_core.dart';
 import 'package:system/system.dart';
 
 import '../../application/quiz_send_money_use_case.dart';
-import '../../domain/payment_quiz_config.dart';
 import '../../infrastructure/payment_quiz_repository_provider.dart';
 import 'send_money_quiz_state.dart';
 
@@ -26,13 +25,13 @@ class SendMoneyQuizNotifier extends AutoDisposeNotifier<SendMoneyQuizState> {
   @override
   SendMoneyQuizState build() {
     ref.onDispose(() => _timer?.cancel());
-    return SendMoneyQuizState.initial(timeLimitSeconds: PaymentQuizConfig.quiz3SendMoneyTimeLimitSeconds);
+    return SendMoneyQuizState.initial();
   }
 
   /// クイズを開始する
   void startQuiz() {
     _timer?.cancel();
-    state = SendMoneyQuizState.initial(timeLimitSeconds: PaymentQuizConfig.quiz3SendMoneyTimeLimitSeconds)
+    state = SendMoneyQuizState.initial()
         .copyWith(
       status: QuizStatus.playing,
       startedAt: clock.now(),
@@ -145,7 +144,7 @@ class SendMoneyQuizNotifier extends AutoDisposeNotifier<SendMoneyQuizState> {
   void retry() {
     _timer?.cancel();
     ref.read(analyticsServiceProvider).logQuizRetried(quizId: _quizId);
-    state = SendMoneyQuizState.initial(timeLimitSeconds: PaymentQuizConfig.quiz3SendMoneyTimeLimitSeconds)
+    state = SendMoneyQuizState.initial()
         .copyWith(
       status: QuizStatus.playing,
       startedAt: clock.now(),

--- a/packages/quizzes/payment/lib/src/presentation/quiz3_send_money/send_money_quiz_state.dart
+++ b/packages/quizzes/payment/lib/src/presentation/quiz3_send_money/send_money_quiz_state.dart
@@ -1,5 +1,7 @@
 import 'package:quiz_core/quiz_core.dart';
 
+import '../../domain/payment_quiz_config.dart';
+
 /// Quiz 3「送金する」の状態
 class SendMoneyQuizState extends QuizStateBase {
   /// コンストラクタ
@@ -17,7 +19,7 @@ class SendMoneyQuizState extends QuizStateBase {
   });
 
   /// 初期状態を生成する
-  factory SendMoneyQuizState.initial({int timeLimitSeconds = 60}) =>
+  factory SendMoneyQuizState.initial() =>
       SendMoneyQuizState(
         status: QuizStatus.idle,
         failureCount: 0,
@@ -27,7 +29,7 @@ class SendMoneyQuizState extends QuizStateBase {
         selectedContactId: null,
         amount: 0,
         moneySent: false,
-        remainingSeconds: timeLimitSeconds,
+        remainingSeconds: PaymentQuizConfig.quiz3SendMoneyTimeLimitSeconds,
         hintUsed: false,
       );
 

--- a/packages/quizzes/payment/lib/src/presentation/quiz4_change_payment_method/change_payment_method_quiz_notifier.dart
+++ b/packages/quizzes/payment/lib/src/presentation/quiz4_change_payment_method/change_payment_method_quiz_notifier.dart
@@ -7,7 +7,6 @@ import 'package:system/system.dart';
 
 import '../../application/quiz_change_payment_method_use_case.dart';
 import '../../domain/payment_method.dart';
-import '../../domain/payment_quiz_config.dart';
 import '../../infrastructure/payment_quiz_repository_provider.dart';
 import 'change_payment_method_quiz_state.dart';
 
@@ -28,17 +27,13 @@ class ChangePaymentMethodQuizNotifier
   @override
   ChangePaymentMethodQuizState build() {
     ref.onDispose(() => _timer?.cancel());
-    return ChangePaymentMethodQuizState.initial(
-      timeLimitSeconds: PaymentQuizConfig.quiz4ChangePaymentMethodTimeLimitSeconds,
-    );
+    return ChangePaymentMethodQuizState.initial();
   }
 
   /// クイズを開始する
   void startQuiz() {
     _timer?.cancel();
-    state = ChangePaymentMethodQuizState.initial(
-      timeLimitSeconds: PaymentQuizConfig.quiz4ChangePaymentMethodTimeLimitSeconds,
-    ).copyWith(
+    state = ChangePaymentMethodQuizState.initial().copyWith(
       status: QuizStatus.playing,
       startedAt: clock.now(),
     );
@@ -96,9 +91,7 @@ class ChangePaymentMethodQuizNotifier
   void retry() {
     _timer?.cancel();
     ref.read(analyticsServiceProvider).logQuizRetried(quizId: _quizId);
-    state = ChangePaymentMethodQuizState.initial(
-      timeLimitSeconds: PaymentQuizConfig.quiz4ChangePaymentMethodTimeLimitSeconds,
-    ).copyWith(
+    state = ChangePaymentMethodQuizState.initial().copyWith(
       status: QuizStatus.playing,
       startedAt: clock.now(),
       failureCount: state.failureCount,

--- a/packages/quizzes/payment/lib/src/presentation/quiz4_change_payment_method/change_payment_method_quiz_state.dart
+++ b/packages/quizzes/payment/lib/src/presentation/quiz4_change_payment_method/change_payment_method_quiz_state.dart
@@ -1,6 +1,7 @@
 import 'package:quiz_core/quiz_core.dart';
 
 import '../../domain/payment_method.dart';
+import '../../domain/payment_quiz_config.dart';
 
 /// Quiz 4「支払い元を変更してバーコードを提示する」の状態
 class ChangePaymentMethodQuizState extends QuizStateBase {
@@ -17,7 +18,7 @@ class ChangePaymentMethodQuizState extends QuizStateBase {
   });
 
   /// 初期状態を生成する
-  factory ChangePaymentMethodQuizState.initial({int timeLimitSeconds = 60}) =>
+  factory ChangePaymentMethodQuizState.initial() =>
       ChangePaymentMethodQuizState(
         status: QuizStatus.idle,
         failureCount: 0,
@@ -25,7 +26,8 @@ class ChangePaymentMethodQuizState extends QuizStateBase {
         startedAt: null,
         currentPaymentMethod: PaymentMethod.balance,
         paymentScreenShown: false,
-        remainingSeconds: timeLimitSeconds,
+        remainingSeconds:
+            PaymentQuizConfig.quiz4ChangePaymentMethodTimeLimitSeconds,
         hintUsed: false,
       );
 

--- a/packages/quizzes/shopping/lib/src/domain/shopping_quiz_config.dart
+++ b/packages/quizzes/shopping/lib/src/domain/shopping_quiz_config.dart
@@ -1,6 +1,6 @@
 abstract final class ShoppingQuizConfig {
   static const waterTimeLimitSeconds = 60;
-  static const cartTimeLimitSeconds = 60;
-  static const checkoutTimeLimitSeconds = 90;
-  static const reorderTimeLimitSeconds = 300;
+  static const cartTimeLimitSeconds = 300;
+  static const checkoutTimeLimitSeconds = 60;
+  static const reorderTimeLimitSeconds = 90;
 }

--- a/packages/quizzes/shopping/lib/src/presentation/cart_quiz/cart_quiz_notifier.dart
+++ b/packages/quizzes/shopping/lib/src/presentation/cart_quiz/cart_quiz_notifier.dart
@@ -4,7 +4,6 @@ import 'package:clock/clock.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:quiz_core/quiz_core.dart';
 import 'package:shopping/src/application/quiz_cart_use_case.dart';
-import 'package:shopping/src/domain/shopping_quiz_config.dart';
 import 'package:system/system.dart';
 import 'package:shopping/src/domain/entities/shopping_cart.dart';
 import 'package:shopping/src/infrastructure/shopping_quiz_repository_provider.dart';
@@ -29,10 +28,9 @@ class CartQuizNotifier extends AutoDisposeNotifier<CartQuizState> {
 
   /// クイズを開始する（タイマー始動）
   void startQuiz() {
-    state = state.copyWith(
+    state = CartQuizState.initial().copyWith(
       status: QuizStatus.playing,
       startedAt: clock.now(),
-      remainingSeconds: ShoppingQuizConfig.cartTimeLimitSeconds,
     );
     ref.read(analyticsServiceProvider).logQuizStarted(quizId: _quizId);
     _startTimer();

--- a/packages/quizzes/shopping/lib/src/presentation/cart_quiz/cart_quiz_notifier.dart
+++ b/packages/quizzes/shopping/lib/src/presentation/cart_quiz/cart_quiz_notifier.dart
@@ -24,7 +24,7 @@ class CartQuizNotifier extends AutoDisposeNotifier<CartQuizState> {
   @override
   CartQuizState build() {
     ref.onDispose(() => _timer?.cancel());
-    return CartQuizState.initial(timeLimitSeconds: ShoppingQuizConfig.cartTimeLimitSeconds);
+    return CartQuizState.initial();
   }
 
   /// クイズを開始する（タイマー始動）
@@ -110,7 +110,7 @@ class CartQuizNotifier extends AutoDisposeNotifier<CartQuizState> {
   void retry() {
     _timer?.cancel();
     ref.read(analyticsServiceProvider).logQuizRetried(quizId: _quizId);
-    state = CartQuizState.initial(timeLimitSeconds: ShoppingQuizConfig.cartTimeLimitSeconds).copyWith(
+    state = CartQuizState.initial().copyWith(
       status: QuizStatus.playing,
       startedAt: clock.now(),
       failureCount: state.failureCount,

--- a/packages/quizzes/shopping/lib/src/presentation/cart_quiz/cart_quiz_state.dart
+++ b/packages/quizzes/shopping/lib/src/presentation/cart_quiz/cart_quiz_state.dart
@@ -1,4 +1,5 @@
 import 'package:quiz_core/quiz_core.dart';
+import 'package:shopping/src/domain/shopping_quiz_config.dart';
 
 /// カート合計金額クイズの状態
 class CartQuizState extends QuizStateBase {
@@ -48,11 +49,11 @@ class CartQuizState extends QuizStateBase {
     );
   }
 
-  factory CartQuizState.initial({int timeLimitSeconds = 60}) => CartQuizState(
+  factory CartQuizState.initial() => CartQuizState(
         status: QuizStatus.idle,
         failureCount: 0,
         elapsedMs: 0,
         startedAt: null,
-        remainingSeconds: timeLimitSeconds,
+        remainingSeconds: ShoppingQuizConfig.cartTimeLimitSeconds,
       );
 }

--- a/packages/quizzes/shopping/lib/src/presentation/checkout_quiz/checkout_quiz_notifier.dart
+++ b/packages/quizzes/shopping/lib/src/presentation/checkout_quiz/checkout_quiz_notifier.dart
@@ -23,7 +23,7 @@ class CheckoutQuizNotifier extends AutoDisposeNotifier<CheckoutQuizState> {
   @override
   CheckoutQuizState build() {
     ref.onDispose(() => _timer?.cancel());
-    return CheckoutQuizState.initial(timeLimitSeconds: ShoppingQuizConfig.checkoutTimeLimitSeconds);
+    return CheckoutQuizState.initial();
   }
 
   /// クイズを開始する（タイマー始動）
@@ -115,8 +115,7 @@ class CheckoutQuizNotifier extends AutoDisposeNotifier<CheckoutQuizState> {
   void retry() {
     _timer?.cancel();
     ref.read(analyticsServiceProvider).logQuizRetried(quizId: _quizId);
-    state = CheckoutQuizState.initial(timeLimitSeconds: ShoppingQuizConfig.checkoutTimeLimitSeconds)
-        .copyWith(
+    state = CheckoutQuizState.initial().copyWith(
       status: QuizStatus.playing,
       startedAt: clock.now(),
       failureCount: state.failureCount,

--- a/packages/quizzes/shopping/lib/src/presentation/checkout_quiz/checkout_quiz_notifier.dart
+++ b/packages/quizzes/shopping/lib/src/presentation/checkout_quiz/checkout_quiz_notifier.dart
@@ -4,7 +4,6 @@ import 'package:clock/clock.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:quiz_core/quiz_core.dart';
 import 'package:shopping/src/application/quiz_checkout_use_case.dart';
-import 'package:shopping/src/domain/shopping_quiz_config.dart';
 import 'package:system/system.dart';
 import 'package:shopping/src/infrastructure/shopping_quiz_repository_provider.dart';
 import 'package:shopping/src/presentation/checkout_quiz/checkout_quiz_state.dart';
@@ -29,10 +28,9 @@ class CheckoutQuizNotifier extends AutoDisposeNotifier<CheckoutQuizState> {
   /// クイズを開始する（タイマー始動）
   void startQuiz() {
     _timer?.cancel();
-    state = state.copyWith(
+    state = CheckoutQuizState.initial().copyWith(
       status: QuizStatus.playing,
       startedAt: clock.now(),
-      remainingSeconds: ShoppingQuizConfig.checkoutTimeLimitSeconds,
     );
     ref.read(analyticsServiceProvider).logQuizStarted(quizId: _quizId);
     _startTimer();

--- a/packages/quizzes/shopping/lib/src/presentation/checkout_quiz/checkout_quiz_state.dart
+++ b/packages/quizzes/shopping/lib/src/presentation/checkout_quiz/checkout_quiz_state.dart
@@ -1,4 +1,5 @@
 import 'package:quiz_core/quiz_core.dart';
+import 'package:shopping/src/domain/shopping_quiz_config.dart';
 
 /// 購入手続きクイズの状態
 class CheckoutQuizState extends QuizStateBase {
@@ -47,12 +48,12 @@ class CheckoutQuizState extends QuizStateBase {
     );
   }
 
-  factory CheckoutQuizState.initial({int timeLimitSeconds = 90}) =>
+  factory CheckoutQuizState.initial() =>
       CheckoutQuizState(
         status: QuizStatus.idle,
         failureCount: 0,
         elapsedMs: 0,
         startedAt: null,
-        remainingSeconds: timeLimitSeconds,
+        remainingSeconds: ShoppingQuizConfig.checkoutTimeLimitSeconds,
       );
 }

--- a/packages/quizzes/shopping/lib/src/presentation/reorder_quiz/reorder_quiz_notifier.dart
+++ b/packages/quizzes/shopping/lib/src/presentation/reorder_quiz/reorder_quiz_notifier.dart
@@ -4,10 +4,8 @@ import 'package:clock/clock.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:quiz_core/quiz_core.dart';
 import 'package:shopping/src/application/quiz_reorder_use_case.dart';
-import 'package:shopping/src/domain/shopping_quiz_config.dart';
 import 'package:system/system.dart';
 import 'package:shopping/src/domain/entities/cart_item.dart';
-import 'package:shopping/src/domain/entities/shopping_cart.dart';
 import 'package:shopping/src/infrastructure/shopping_quiz_repository_provider.dart';
 import 'package:shopping/src/presentation/reorder_quiz/reorder_quiz_state.dart';
 
@@ -35,13 +33,9 @@ class ReorderQuizNotifier extends AutoDisposeNotifier<ReorderQuizState> {
 
   void startQuiz() {
     _timer?.cancel();
-    state = state.copyWith(
+    state = ReorderQuizState.initial(targetItemId: _targetItemId).copyWith(
       status: QuizStatus.playing,
       startedAt: clock.now(),
-      cart: const ShoppingCart(),
-      isPurchased: false,
-      remainingSeconds: ShoppingQuizConfig.reorderTimeLimitSeconds,
-      hintUsed: false,
     );
     ref.read(analyticsServiceProvider).logQuizStarted(quizId: _quizId);
     _startTimer();

--- a/packages/quizzes/shopping/lib/src/presentation/reorder_quiz/reorder_quiz_notifier.dart
+++ b/packages/quizzes/shopping/lib/src/presentation/reorder_quiz/reorder_quiz_notifier.dart
@@ -30,7 +30,7 @@ class ReorderQuizNotifier extends AutoDisposeNotifier<ReorderQuizState> {
   @override
   ReorderQuizState build() {
     ref.onDispose(() => _timer?.cancel());
-    return ReorderQuizState.initial(timeLimitSeconds: ShoppingQuizConfig.reorderTimeLimitSeconds);
+    return ReorderQuizState.initial();
   }
 
   void startQuiz() {
@@ -146,7 +146,6 @@ class ReorderQuizNotifier extends AutoDisposeNotifier<ReorderQuizState> {
     _timer?.cancel();
     ref.read(analyticsServiceProvider).logQuizRetried(quizId: _quizId);
     state = ReorderQuizState.initial(
-      timeLimitSeconds: ShoppingQuizConfig.reorderTimeLimitSeconds,
       targetItemId: _targetItemId,
     ).copyWith(
       status: QuizStatus.playing,

--- a/packages/quizzes/shopping/lib/src/presentation/reorder_quiz/reorder_quiz_state.dart
+++ b/packages/quizzes/shopping/lib/src/presentation/reorder_quiz/reorder_quiz_state.dart
@@ -1,5 +1,6 @@
 import 'package:quiz_core/quiz_core.dart';
 import 'package:shopping/src/domain/entities/shopping_cart.dart';
+import 'package:shopping/src/domain/shopping_quiz_config.dart';
 
 class ReorderQuizState extends QuizStateBase {
   const ReorderQuizState({
@@ -51,7 +52,6 @@ class ReorderQuizState extends QuizStateBase {
   }
 
   factory ReorderQuizState.initial({
-    int timeLimitSeconds = 90,
     String targetItemId = 'snack_chips',
   }) =>
       ReorderQuizState(
@@ -61,7 +61,7 @@ class ReorderQuizState extends QuizStateBase {
         startedAt: null,
         cart: const ShoppingCart(),
         isPurchased: false,
-        remainingSeconds: timeLimitSeconds,
+        remainingSeconds: ShoppingQuizConfig.reorderTimeLimitSeconds,
         targetItemId: targetItemId,
       );
 }

--- a/packages/quizzes/shopping/lib/src/presentation/water_quiz/water_quiz_notifier.dart
+++ b/packages/quizzes/shopping/lib/src/presentation/water_quiz/water_quiz_notifier.dart
@@ -29,7 +29,7 @@ class WaterQuizNotifier extends AutoDisposeNotifier<WaterQuizState> {
   @override
   WaterQuizState build() {
     ref.onDispose(() => _timer?.cancel());
-    return WaterQuizState.initial(timeLimitSeconds: ShoppingQuizConfig.waterTimeLimitSeconds);
+    return WaterQuizState.initial();
   }
 
   void startQuiz() {
@@ -132,7 +132,7 @@ class WaterQuizNotifier extends AutoDisposeNotifier<WaterQuizState> {
   void retry() {
     _timer?.cancel();
     ref.read(analyticsServiceProvider).logQuizRetried(quizId: _quizId);
-    state = WaterQuizState.initial(timeLimitSeconds: ShoppingQuizConfig.waterTimeLimitSeconds).copyWith(
+    state = WaterQuizState.initial().copyWith(
       status: QuizStatus.playing,
       startedAt: clock.now(),
     );

--- a/packages/quizzes/shopping/lib/src/presentation/water_quiz/water_quiz_notifier.dart
+++ b/packages/quizzes/shopping/lib/src/presentation/water_quiz/water_quiz_notifier.dart
@@ -4,10 +4,8 @@ import 'package:clock/clock.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:quiz_core/quiz_core.dart';
 import 'package:shopping/src/application/quiz_water_use_case.dart';
-import 'package:shopping/src/domain/shopping_quiz_config.dart';
 import 'package:system/system.dart';
 import 'package:shopping/src/domain/entities/cart_item.dart';
-import 'package:shopping/src/domain/entities/shopping_cart.dart';
 import 'package:shopping/src/infrastructure/shopping_quiz_repository_provider.dart';
 import 'package:shopping/src/presentation/water_quiz/water_quiz_state.dart';
 
@@ -34,12 +32,9 @@ class WaterQuizNotifier extends AutoDisposeNotifier<WaterQuizState> {
 
   void startQuiz() {
     _timer?.cancel();
-    state = state.copyWith(
+    state = WaterQuizState.initial().copyWith(
       status: QuizStatus.playing,
       startedAt: clock.now(),
-      cart: const ShoppingCart(),
-      isPurchased: false,
-      remainingSeconds: ShoppingQuizConfig.waterTimeLimitSeconds,
     );
     ref.read(analyticsServiceProvider).logQuizStarted(quizId: _quizId);
     _startTimer();

--- a/packages/quizzes/shopping/lib/src/presentation/water_quiz/water_quiz_state.dart
+++ b/packages/quizzes/shopping/lib/src/presentation/water_quiz/water_quiz_state.dart
@@ -1,5 +1,6 @@
 import 'package:quiz_core/quiz_core.dart';
 import 'package:shopping/src/domain/entities/shopping_cart.dart';
+import 'package:shopping/src/domain/shopping_quiz_config.dart';
 
 class WaterQuizState extends QuizStateBase {
   const WaterQuizState({
@@ -50,13 +51,13 @@ class WaterQuizState extends QuizStateBase {
     );
   }
 
-  factory WaterQuizState.initial({int timeLimitSeconds = 60}) => WaterQuizState(
+  factory WaterQuizState.initial() => WaterQuizState(
         status: QuizStatus.idle,
         failureCount: 0,
         elapsedMs: 0,
         startedAt: null,
         cart: const ShoppingCart(),
         isPurchased: false,
-        remainingSeconds: timeLimitSeconds,
+        remainingSeconds: ShoppingQuizConfig.waterTimeLimitSeconds,
       );
 }

--- a/packages/quizzes/streaming/lib/src/presentation/quiz1_subtitle/subtitle_quiz_notifier.dart
+++ b/packages/quizzes/streaming/lib/src/presentation/quiz1_subtitle/subtitle_quiz_notifier.dart
@@ -6,7 +6,6 @@ import 'package:quiz_core/quiz_core.dart';
 import 'package:streaming/src/application/quiz_subtitle_use_case.dart';
 import 'package:system/system.dart';
 import 'package:streaming/src/domain/streaming_catalog.dart';
-import 'package:streaming/src/domain/streaming_quiz_config.dart';
 import 'package:streaming/src/infrastructure/streaming_quiz_repository_provider.dart';
 import 'package:streaming/src/presentation/quiz1_subtitle/subtitle_quiz_state.dart';
 
@@ -26,7 +25,6 @@ class SubtitleQuizNotifier extends AutoDisposeNotifier<SubtitleQuizState> {
     ref.onDispose(() => _timer?.cancel());
     return SubtitleQuizState.initial(
       video: StreamingCatalog.featuredVideo,
-      timeLimitSeconds: StreamingQuizConfig.quiz1SubtitleTimeLimitSeconds,
     );
   }
 
@@ -34,7 +32,6 @@ class SubtitleQuizNotifier extends AutoDisposeNotifier<SubtitleQuizState> {
     _timer?.cancel();
     state = SubtitleQuizState.initial(
       video: StreamingCatalog.featuredVideo,
-      timeLimitSeconds: StreamingQuizConfig.quiz1SubtitleTimeLimitSeconds,
     ).copyWith(
       status: QuizStatus.playing,
       startedAt: clock.now(),
@@ -133,7 +130,6 @@ class SubtitleQuizNotifier extends AutoDisposeNotifier<SubtitleQuizState> {
     ref.read(analyticsServiceProvider).logQuizRetried(quizId: _quizId);
     state = SubtitleQuizState.initial(
       video: StreamingCatalog.featuredVideo,
-      timeLimitSeconds: StreamingQuizConfig.quiz1SubtitleTimeLimitSeconds,
     ).copyWith(
       status: QuizStatus.playing,
       startedAt: clock.now(),

--- a/packages/quizzes/streaming/lib/src/presentation/quiz1_subtitle/subtitle_quiz_state.dart
+++ b/packages/quizzes/streaming/lib/src/presentation/quiz1_subtitle/subtitle_quiz_state.dart
@@ -1,5 +1,6 @@
 import 'package:quiz_core/quiz_core.dart';
 import 'package:streaming/src/domain/entities/streaming_video.dart';
+import 'package:streaming/src/domain/streaming_quiz_config.dart';
 
 class SubtitleQuizState extends QuizStateBase {
   const SubtitleQuizState({
@@ -38,7 +39,6 @@ class SubtitleQuizState extends QuizStateBase {
 
   factory SubtitleQuizState.initial({
     required StreamingVideo video,
-    int timeLimitSeconds = 30,
   }) =>
       SubtitleQuizState(
         status: QuizStatus.idle,
@@ -46,7 +46,7 @@ class SubtitleQuizState extends QuizStateBase {
         elapsedMs: 0,
         startedAt: null,
         video: video,
-        remainingSeconds: timeLimitSeconds,
+        remainingSeconds: StreamingQuizConfig.quiz1SubtitleTimeLimitSeconds,
         isSettingsOpen: false,
       );
 }

--- a/packages/quizzes/streaming/lib/src/presentation/quiz2_skip_seek/skip_seek_quiz_notifier.dart
+++ b/packages/quizzes/streaming/lib/src/presentation/quiz2_skip_seek/skip_seek_quiz_notifier.dart
@@ -6,7 +6,6 @@ import 'package:quiz_core/quiz_core.dart';
 import 'package:streaming/src/application/quiz_skip_seek_use_case.dart';
 import 'package:system/system.dart';
 import 'package:streaming/src/domain/streaming_catalog.dart';
-import 'package:streaming/src/domain/streaming_quiz_config.dart';
 import 'package:streaming/src/infrastructure/streaming_quiz_repository_provider.dart';
 import 'package:streaming/src/presentation/quiz2_skip_seek/skip_seek_quiz_state.dart';
 
@@ -26,7 +25,6 @@ class SkipSeekQuizNotifier extends AutoDisposeNotifier<SkipSeekQuizState> {
     ref.onDispose(() => _timer?.cancel());
     return SkipSeekQuizState.initial(
       video: StreamingCatalog.videos[1], // Quiz 2用の動画
-      timeLimitSeconds: StreamingQuizConfig.quiz2SkipSeekTimeLimitSeconds,
     );
   }
 
@@ -34,7 +32,6 @@ class SkipSeekQuizNotifier extends AutoDisposeNotifier<SkipSeekQuizState> {
     _timer?.cancel();
     state = SkipSeekQuizState.initial(
       video: StreamingCatalog.videos[1],
-      timeLimitSeconds: StreamingQuizConfig.quiz2SkipSeekTimeLimitSeconds,
     ).copyWith(
       status: QuizStatus.playing,
       startedAt: clock.now(),
@@ -150,7 +147,6 @@ class SkipSeekQuizNotifier extends AutoDisposeNotifier<SkipSeekQuizState> {
     ref.read(analyticsServiceProvider).logQuizRetried(quizId: _quizId);
     state = SkipSeekQuizState.initial(
       video: StreamingCatalog.videos[1],
-      timeLimitSeconds: StreamingQuizConfig.quiz2SkipSeekTimeLimitSeconds,
     ).copyWith(
       status: QuizStatus.playing,
       startedAt: clock.now(),

--- a/packages/quizzes/streaming/lib/src/presentation/quiz2_skip_seek/skip_seek_quiz_state.dart
+++ b/packages/quizzes/streaming/lib/src/presentation/quiz2_skip_seek/skip_seek_quiz_state.dart
@@ -1,5 +1,6 @@
 import 'package:quiz_core/quiz_core.dart';
 import 'package:streaming/src/domain/entities/streaming_video.dart';
+import 'package:streaming/src/domain/streaming_quiz_config.dart';
 
 class SkipSeekQuizState extends QuizStateBase {
   const SkipSeekQuizState({
@@ -46,7 +47,6 @@ class SkipSeekQuizState extends QuizStateBase {
 
   factory SkipSeekQuizState.initial({
     required StreamingVideo video,
-    int timeLimitSeconds = 45,
   }) =>
       SkipSeekQuizState(
         status: QuizStatus.idle,
@@ -56,7 +56,7 @@ class SkipSeekQuizState extends QuizStateBase {
         video: video,
         progressSeconds: 0,
         isSkipped: false,
-        remainingSeconds: timeLimitSeconds,
+        remainingSeconds: StreamingQuizConfig.quiz2SkipSeekTimeLimitSeconds,
         isSettingsOpen: false,
       );
 }

--- a/packages/quizzes/streaming/lib/src/presentation/quiz3_playback_speed/playback_speed_quiz_notifier.dart
+++ b/packages/quizzes/streaming/lib/src/presentation/quiz3_playback_speed/playback_speed_quiz_notifier.dart
@@ -6,7 +6,6 @@ import 'package:quiz_core/quiz_core.dart';
 import 'package:streaming/src/application/quiz_playback_speed_use_case.dart';
 import 'package:system/system.dart';
 import 'package:streaming/src/domain/streaming_catalog.dart';
-import 'package:streaming/src/domain/streaming_quiz_config.dart';
 import 'package:streaming/src/infrastructure/streaming_quiz_repository_provider.dart';
 import 'package:streaming/src/presentation/quiz3_playback_speed/playback_speed_quiz_state.dart';
 
@@ -26,7 +25,6 @@ class PlaybackSpeedQuizNotifier extends AutoDisposeNotifier<PlaybackSpeedQuizSta
     ref.onDispose(() => _timer?.cancel());
     return PlaybackSpeedQuizState.initial(
       video: StreamingCatalog.videos[2], // Quiz 3用の動画
-      timeLimitSeconds: StreamingQuizConfig.quiz3PlaybackSpeedTimeLimitSeconds,
     );
   }
 
@@ -34,7 +32,6 @@ class PlaybackSpeedQuizNotifier extends AutoDisposeNotifier<PlaybackSpeedQuizSta
     _timer?.cancel();
     state = PlaybackSpeedQuizState.initial(
       video: StreamingCatalog.videos[2],
-      timeLimitSeconds: StreamingQuizConfig.quiz3PlaybackSpeedTimeLimitSeconds,
     ).copyWith(
       status: QuizStatus.playing,
       startedAt: clock.now(),
@@ -150,7 +147,6 @@ class PlaybackSpeedQuizNotifier extends AutoDisposeNotifier<PlaybackSpeedQuizSta
     ref.read(analyticsServiceProvider).logQuizRetried(quizId: _quizId);
     state = PlaybackSpeedQuizState.initial(
       video: StreamingCatalog.videos[2],
-      timeLimitSeconds: StreamingQuizConfig.quiz3PlaybackSpeedTimeLimitSeconds,
     ).copyWith(
       status: QuizStatus.playing,
       startedAt: clock.now(),

--- a/packages/quizzes/streaming/lib/src/presentation/quiz3_playback_speed/playback_speed_quiz_state.dart
+++ b/packages/quizzes/streaming/lib/src/presentation/quiz3_playback_speed/playback_speed_quiz_state.dart
@@ -1,5 +1,6 @@
 import 'package:quiz_core/quiz_core.dart';
 import 'package:streaming/src/domain/entities/streaming_video.dart';
+import 'package:streaming/src/domain/streaming_quiz_config.dart';
 
 class PlaybackSpeedQuizState extends QuizStateBase {
   const PlaybackSpeedQuizState({
@@ -42,7 +43,6 @@ class PlaybackSpeedQuizState extends QuizStateBase {
 
   factory PlaybackSpeedQuizState.initial({
     required StreamingVideo video,
-    int timeLimitSeconds = 60,
   }) =>
       PlaybackSpeedQuizState(
         status: QuizStatus.idle,
@@ -50,7 +50,8 @@ class PlaybackSpeedQuizState extends QuizStateBase {
         elapsedMs: 0,
         startedAt: null,
         video: video,
-        remainingSeconds: timeLimitSeconds,
+        remainingSeconds:
+            StreamingQuizConfig.quiz3PlaybackSpeedTimeLimitSeconds,
         isSettingsOpen: false,
         isSpeedListOpen: false,
       );

--- a/packages/quizzes/streaming/lib/src/presentation/quiz4_offline_save/offline_save_quiz_notifier.dart
+++ b/packages/quizzes/streaming/lib/src/presentation/quiz4_offline_save/offline_save_quiz_notifier.dart
@@ -6,7 +6,6 @@ import 'package:quiz_core/quiz_core.dart';
 import 'package:streaming/src/application/quiz_offline_save_use_case.dart';
 import 'package:system/system.dart';
 import 'package:streaming/src/domain/streaming_catalog.dart';
-import 'package:streaming/src/domain/streaming_quiz_config.dart';
 import 'package:streaming/src/infrastructure/streaming_quiz_repository_provider.dart';
 import 'package:streaming/src/presentation/quiz4_offline_save/offline_save_quiz_state.dart';
 
@@ -26,7 +25,6 @@ class OfflineSaveQuizNotifier extends AutoDisposeNotifier<OfflineSaveQuizState> 
     ref.onDispose(() => _timer?.cancel());
     return OfflineSaveQuizState.initial(
       video: StreamingCatalog.videos[3].copyWith(quality: '360p'), // 初期画質を低く設定
-      timeLimitSeconds: StreamingQuizConfig.quiz4OfflineSaveTimeLimitSeconds,
     );
   }
 
@@ -34,7 +32,6 @@ class OfflineSaveQuizNotifier extends AutoDisposeNotifier<OfflineSaveQuizState> 
     _timer?.cancel();
     state = OfflineSaveQuizState.initial(
       video: StreamingCatalog.videos[3].copyWith(quality: '360p'),
-      timeLimitSeconds: StreamingQuizConfig.quiz4OfflineSaveTimeLimitSeconds,
     ).copyWith(
       status: QuizStatus.playing,
       startedAt: clock.now(),
@@ -168,7 +165,6 @@ class OfflineSaveQuizNotifier extends AutoDisposeNotifier<OfflineSaveQuizState> 
     ref.read(analyticsServiceProvider).logQuizRetried(quizId: _quizId);
     state = OfflineSaveQuizState.initial(
       video: StreamingCatalog.videos[3].copyWith(quality: '360p'),
-      timeLimitSeconds: StreamingQuizConfig.quiz4OfflineSaveTimeLimitSeconds,
     ).copyWith(
       status: QuizStatus.playing,
       startedAt: clock.now(),

--- a/packages/quizzes/streaming/lib/src/presentation/quiz4_offline_save/offline_save_quiz_state.dart
+++ b/packages/quizzes/streaming/lib/src/presentation/quiz4_offline_save/offline_save_quiz_state.dart
@@ -1,5 +1,6 @@
 import 'package:quiz_core/quiz_core.dart';
 import 'package:streaming/src/domain/entities/streaming_video.dart';
+import 'package:streaming/src/domain/streaming_quiz_config.dart';
 
 class OfflineSaveQuizState extends QuizStateBase {
   const OfflineSaveQuizState({
@@ -42,7 +43,6 @@ class OfflineSaveQuizState extends QuizStateBase {
 
   factory OfflineSaveQuizState.initial({
     required StreamingVideo video,
-    int timeLimitSeconds = 90,
   }) =>
       OfflineSaveQuizState(
         status: QuizStatus.idle,
@@ -50,7 +50,7 @@ class OfflineSaveQuizState extends QuizStateBase {
         elapsedMs: 0,
         startedAt: null,
         video: video,
-        remainingSeconds: timeLimitSeconds,
+        remainingSeconds: StreamingQuizConfig.quiz4OfflineSaveTimeLimitSeconds,
         isSettingsOpen: false,
         isQualityListOpen: false,
       );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

* **改善**
  * クイズのタイムリミット設定を一元管理に変更し、コード保守性を向上
  * ショッピングクイズのタイムリミットを調整：カートクイズは60秒から300秒に、チェックアウトクイズは90秒から60秒に、並べ替えクイズは300秒から90秒に変更

<!-- end of auto-generated comment: release notes by coderabbit.ai -->