### PR TITLE
Add music player quiz package with UI improvements and refactor

### DIFF
--- a/apps/app_main/lib/config/route_path_constants.dart
+++ b/apps/app_main/lib/config/route_path_constants.dart
@@ -102,6 +102,13 @@ const String kMatchingQuiz2Path = '$kMatchingListPath/$kMatchingQuiz2Segment';
 const String kMatchingQuiz3Path = '$kMatchingListPath/$kMatchingQuiz3Segment';
 const String kMatchingQuiz4Path = '$kMatchingListPath/$kMatchingQuiz4Segment';
 
+// Music
+const String kMusicListPath = '/play/music';
+const String kMusicQuiz1Path = '/play/music/quiz1';
+const String kMusicQuiz2Path = '/play/music/quiz2';
+const String kMusicQuiz3Path = '/play/music/quiz3';
+const String kMusicQuiz4Path = '/play/music/quiz4';
+
 // Comic
 const String kComicSegment = 'comic';
 const String kComicQuiz1Segment = 'quiz1';

--- a/apps/app_main/lib/domain/category.dart
+++ b/apps/app_main/lib/domain/category.dart
@@ -14,7 +14,8 @@ enum QuizCategory {
   sns,
   comic,
   todo,
-  matching
+  matching,
+  music
   ;
 
   String get id => name;
@@ -33,6 +34,7 @@ enum QuizCategory {
     comic => Icons.menu_book_rounded,
     todo => Icons.check_box_outlined,
     matching => Icons.favorite_outline,
+    music => Icons.music_note_outlined,
   };
 
   bool get isComingSoon => false;
@@ -51,6 +53,7 @@ enum QuizCategory {
     comic => t.play.categoryLabel.comic,
     todo => t.play.categoryLabel.todo,
     matching => t.play.categoryLabel.matching,
+    music => t.play.categoryLabel.music,
   };
 
   Color color(NantoNackThemeExtension ext) => switch (this) {
@@ -67,6 +70,7 @@ enum QuizCategory {
     comic => ext.comicCategoryColor,
     todo => ext.todoCategoryColor,
     matching => ext.matchingCategoryColor,
+    music => ext.musicCategoryColor,
   };
 
   Color containerColor(NantoNackThemeExtension ext) => switch (this) {
@@ -83,6 +87,7 @@ enum QuizCategory {
     comic => ext.comicCategoryContainerColor,
     todo => ext.todoCategoryContainerColor,
     matching => ext.matchingCategoryContainerColor,
+    music => ext.musicCategoryContainerColor,
   };
 
   static QuizCategory fromId(String id) => QuizCategory.values.firstWhere(

--- a/apps/app_main/lib/domain/stage.dart
+++ b/apps/app_main/lib/domain/stage.dart
@@ -25,6 +25,7 @@ enum GenericQuizStage {
             QuizCategory.comic => t.play.stageTitle.comic_quiz1,
             QuizCategory.todo => t.play.stageTitle.todo_quiz1,
             QuizCategory.matching => t.play.stageTitle.matching_quiz1,
+            QuizCategory.music => t.play.stageTitle.music_quiz1,
           },
         quiz2 => switch (category) {
             QuizCategory.shopping => t.play.stageTitle.shopping_quiz2,
@@ -40,6 +41,7 @@ enum GenericQuizStage {
             QuizCategory.comic => t.play.stageTitle.comic_quiz2,
             QuizCategory.todo => t.play.stageTitle.todo_quiz2,
             QuizCategory.matching => t.play.stageTitle.matching_quiz2,
+            QuizCategory.music => t.play.stageTitle.music_quiz2,
           },
         quiz3 => switch (category) {
             QuizCategory.shopping => t.play.stageTitle.shopping_quiz3,
@@ -55,6 +57,7 @@ enum GenericQuizStage {
             QuizCategory.comic => t.play.stageTitle.comic_quiz3,
             QuizCategory.todo => t.play.stageTitle.todo_quiz3,
             QuizCategory.matching => t.play.stageTitle.matching_quiz3,
+            QuizCategory.music => t.play.stageTitle.music_quiz3,
           },
         quiz4 => switch (category) {
             QuizCategory.shopping => t.play.stageTitle.shopping_quiz4,
@@ -70,6 +73,7 @@ enum GenericQuizStage {
             QuizCategory.comic => t.play.stageTitle.comic_quiz4,
             QuizCategory.todo => t.play.stageTitle.todo_quiz4,
             QuizCategory.matching => t.play.stageTitle.matching_quiz4,
+            QuizCategory.music => t.play.stageTitle.music_quiz4,
           },
       };
 
@@ -427,6 +431,31 @@ final List<Stage> kAllStages = List.unmodifiable([
     category: QuizCategory.comic,
     routePath: kComicQuiz4Path,
     difficulty: 2,
+  ),
+  // 音楽カテゴリー
+  const Stage(
+    id: 'music_quiz1',
+    category: QuizCategory.music,
+    routePath: kMusicQuiz1Path,
+    difficulty: 1,
+  ),
+  const Stage(
+    id: 'music_quiz2',
+    category: QuizCategory.music,
+    routePath: kMusicQuiz2Path,
+    difficulty: 2,
+  ),
+  const Stage(
+    id: 'music_quiz3',
+    category: QuizCategory.music,
+    routePath: kMusicQuiz3Path,
+    difficulty: 3,
+  ),
+  const Stage(
+    id: 'music_quiz4',
+    category: QuizCategory.music,
+    routePath: kMusicQuiz4Path,
+    difficulty: 4,
   ),
 ]);
 

--- a/apps/app_main/lib/router.dart
+++ b/apps/app_main/lib/router.dart
@@ -12,6 +12,7 @@ import 'presentation/splash/splash_screen.dart';
 import 'presentation/support/support_screen.dart';
 import 'router/alarm_router.dart';
 import 'router/matching_router.dart';
+import 'router/music_router.dart';
 import 'router/calendar_router.dart';
 import 'router/chat_router.dart';
 import 'router/comic_router.dart';
@@ -75,6 +76,7 @@ final routerProvider = Provider<GoRouter>((ref) {
           ...snsRoutes,
           ...todoRoutes,
           ...matchingRoutes,
+          ...musicRoutes,
         ],
       ),
       GoRoute(

--- a/apps/app_main/lib/router/music_router.dart
+++ b/apps/app_main/lib/router/music_router.dart
@@ -1,0 +1,39 @@
+import 'package:go_router/go_router.dart';
+import 'package:music/music.dart';
+
+import '../domain/category.dart';
+import '../presentation/play/stage_list_screen.dart';
+
+List<GoRoute> get musicRoutes => [
+      GoRoute(
+        path: 'music',
+        builder: (context, state) =>
+            const StageListScreen(category: QuizCategory.music),
+        routes: [
+          GoRoute(
+            path: 'quiz1',
+            builder: (context, state) => NextSongQuizScreen(
+              onCompleted: () => context.pop(),
+            ),
+          ),
+          GoRoute(
+            path: 'quiz2',
+            builder: (context, state) => MinimizePlayerQuizScreen(
+              onCompleted: () => context.pop(),
+            ),
+          ),
+          GoRoute(
+            path: 'quiz3',
+            builder: (context, state) => OneRepeatQuizScreen(
+              onCompleted: () => context.pop(),
+            ),
+          ),
+          GoRoute(
+            path: 'quiz4',
+            builder: (context, state) => LyricsQuizScreen(
+              onCompleted: () => context.pop(),
+            ),
+          ),
+        ],
+      ),
+    ];

--- a/apps/app_main/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/apps/app_main/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,7 @@
 import FlutterMacOS
 import Foundation
 
+import audio_session
 import audioplayers_darwin
 import file_selector_macos
 import firebase_analytics
@@ -12,6 +13,7 @@ import firebase_core
 import firebase_crashlytics
 import firebase_remote_config
 import geolocator_apple
+import just_audio
 import package_info_plus
 import purchases_flutter
 import shared_preferences_foundation
@@ -19,6 +21,7 @@ import sqlite3_flutter_libs
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  AudioSessionPlugin.register(with: registry.registrar(forPlugin: "AudioSessionPlugin"))
   AudioplayersDarwinPlugin.register(with: registry.registrar(forPlugin: "AudioplayersDarwinPlugin"))
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   FirebaseAnalyticsPlugin.register(with: registry.registrar(forPlugin: "FirebaseAnalyticsPlugin"))
@@ -26,6 +29,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTFirebaseCrashlyticsPlugin.register(with: registry.registrar(forPlugin: "FLTFirebaseCrashlyticsPlugin"))
   FirebaseRemoteConfigPlugin.register(with: registry.registrar(forPlugin: "FirebaseRemoteConfigPlugin"))
   GeolocatorPlugin.register(with: registry.registrar(forPlugin: "GeolocatorPlugin"))
+  JustAudioPlugin.register(with: registry.registrar(forPlugin: "JustAudioPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PurchasesFlutterPlugin.register(with: registry.registrar(forPlugin: "PurchasesFlutterPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))

--- a/apps/app_main/pubspec.yaml
+++ b/apps/app_main/pubspec.yaml
@@ -58,6 +58,8 @@ dependencies:
     path: ../../packages/quizzes/todo
   matching:
     path: ../../packages/quizzes/matching
+  music:
+    path: ../../packages/quizzes/music
   slang_flutter: ^4.3.1
   system:
     path: ../../packages/system

--- a/packages/quiz_core/assets/i18n/en.i18n.json
+++ b/packages/quiz_core/assets/i18n/en.i18n.json
@@ -116,7 +116,8 @@
       "sns": "SNS",
       "comic": "Manga App",
       "todo": "TODO App",
-      "matching": "Matching"
+      "matching": "Matching",
+      "music": "Music"
     },
     "categoryDescription": {
       "shopping": "Experience e-commerce UI/UX",
@@ -131,7 +132,8 @@
       "sns": "Experience social media app UI/UX",
       "comic": "Master manga app operations",
       "todo": "Experience task management app UI/UX",
-      "matching": "Experience matching app UI/UX"
+      "matching": "Experience matching app UI/UX",
+      "music": "Experience music player UI/UX"
     },
     "stageTitle": {
       "shopping_quiz1": "Buy 2 Waters",
@@ -185,7 +187,11 @@
       "matching_quiz1": "Like someone you're interested in",
       "matching_quiz2": "Not quite your type... skip them",
       "matching_quiz3": "View the second photo",
-      "matching_quiz4": "Your destiny! Send a Super Like"
+      "matching_quiz4": "Your destiny! Send a Super Like",
+      "music_quiz1": "Skip to the next song",
+      "music_quiz2": "Minimize the player",
+      "music_quiz3": "Set to 1-song repeat",
+      "music_quiz4": "Show the lyrics"
     },
     "stageDescription": {
       "shopping_quiz1": "Add 2 waters to the cart and purchase on the e-commerce site",
@@ -239,7 +245,11 @@
       "matching_quiz1": "Swipe right on a profile you like",
       "matching_quiz2": "Swipe left to skip",
       "matching_quiz3": "Tap the right half of the profile card to see the second photo",
-      "matching_quiz4": "Swipe up to send a Super Like"
+      "matching_quiz4": "Swipe up to send a Super Like",
+      "music_quiz1": "Swipe left on the album art or tap the skip button to go to the next song",
+      "music_quiz2": "Swipe down on the full-screen player to minimize it",
+      "music_quiz3": "Tap the repeat button twice to set 1-song repeat",
+      "music_quiz4": "Swipe up the lyrics panel at the bottom of the screen"
     }
   },
   "scene": {

--- a/packages/quiz_core/assets/i18n/ja.i18n.json
+++ b/packages/quiz_core/assets/i18n/ja.i18n.json
@@ -116,7 +116,8 @@
       "sns": "SNS",
       "comic": "漫画アプリ",
       "todo": "タスク管理",
-      "matching": "マッチング"
+      "matching": "マッチング",
+      "music": "音楽"
     },
     "categoryDescription": {
       "shopping": "ECサイトのUI/UXを体験しよう",
@@ -131,7 +132,8 @@
       "sns": "SNSアプリのUI/UXを体験しよう",
       "comic": "漫画アプリの操作をマスターしよう",
       "todo": "TODOアプリのUI/UXを体験しよう",
-      "matching": "マッチングアプリのUI/UXを体験しよう"
+      "matching": "マッチングアプリのUI/UXを体験しよう",
+      "music": "音楽プレイヤーのUI/UXを体験しよう"
     },
     "stageTitle": {
       "shopping_quiz1": "水を2つ買おう",
@@ -185,7 +187,11 @@
       "matching_quiz1": "素敵な人に『いいね』しよう",
       "matching_quiz2": "気が合わなそう……スキップしよう",
       "matching_quiz3": "2枚目の写真を見てみよう",
-      "matching_quiz4": "運命の出会い！『超いいね』を送ろう"
+      "matching_quiz4": "運命の出会い！『超いいね』を送ろう",
+      "music_quiz1": "次の曲に進めよう",
+      "music_quiz2": "再生画面を収納しよう",
+      "music_quiz3": "1曲リピートに設定しよう",
+      "music_quiz4": "歌詞を表示しよう"
     },
     "stageDescription": {
       "shopping_quiz1": "ECサイトで水を2つカートに入れて購入してください",
@@ -239,7 +245,11 @@
       "matching_quiz1": "気になるプロフィールを右にスワイプしていいねしてください",
       "matching_quiz2": "左にスワイプしてスキップしてください",
       "matching_quiz3": "プロフィールカードの右半分をタップして2枚目の写真を見てください",
-      "matching_quiz4": "上にスワイプして超いいねを送ってください"
+      "matching_quiz4": "上にスワイプして超いいねを送ってください",
+      "music_quiz1": "アルバムアートを左にスワイプするか、スキップボタンで次の曲に進んでください",
+      "music_quiz2": "全画面プレイヤーを下にスワイプしてミニプレイヤーに収納してください",
+      "music_quiz3": "リピートボタンを2回タップして1曲リピート状態にしてください",
+      "music_quiz4": "画面下部の歌詞パネルを上にスワイプして引き上げてください"
     }
   },
   "scene": {

--- a/packages/quiz_core/assets/i18n/xx.i18n.json
+++ b/packages/quiz_core/assets/i18n/xx.i18n.json
@@ -116,7 +116,8 @@
       "sns": "SNS",
       "comic": "漫画アプリ",
       "todo": "タスク管理",
-      "matching": "Ekzuyrjp"
+      "matching": "Ekzuyrjp",
+      "music": "Tnwru"
     },
     "categoryDescription": {
       "shopping": "ECサイトのUI/UXを体験しよう",
@@ -131,7 +132,8 @@
       "sns": "SNSアプリのUI/UXを体験しよう",
       "comic": "漫画アプリの操作をマスターしよう",
       "todo": "ZSMS koo HR/HT xtoxfrxjux",
-      "matching": "Ekzuyrjp koo HR/HT xtoxfrxjux"
+      "matching": "Ekzuyrjp koo HR/HT xtoxfrxjux",
+      "music": "Tnwru ockirxf HR/HT xtoxfrxjux"
     },
     "stageTitle": {
       "shopping_quiz1": "水を2つ買おう",
@@ -185,7 +187,11 @@
       "matching_quiz1": "Crax wsexsjx ish'fх rjzxfxwzxm rj",
       "matching_quiz2": "Jsz lhrzx ishf zioх... waро zyxe",
       "matching_quiz3": "Nrxg zyx wxusjm oyszs",
-      "matching_quiz4": "Ishf mxwzrji! Wxjm k Whoef Crax"
+      "matching_quiz4": "Ishf mxwzrji! Wxjm k Whoef Crax",
+      "music_quiz1": "Waро zs jxtz wsjp",
+      "music_quiz2": "Mrjreryx ockirxf",
+      "music_quiz3": "Wxz 1-wsjp fxoxkz",
+      "music_quiz4": "Wysw cifruv"
     },
     "stageDescription": {
       "shopping_quiz1": "ECサイトで水を2つカートに入れて購入してください",
@@ -235,7 +241,11 @@
       "matching_quiz1": "Wgrox frpyz sj k ofsbrcх ish crax",
       "matching_quiz2": "Wgrox cxbz zs waро",
       "matching_quiz3": "Zko zyx frpyz ykcb sb zyx ofsbrcх ukfm zs wxx zyx wxusjm oyszs",
-      "matching_quiz4": "Wgrox ho zs wxjm k Whoef Crax"
+      "matching_quiz4": "Wgrox ho zs wxjm k Whoef Crax",
+      "music_quiz1": "Wgrox cxbz sj kcbhe kfz sf zko waро",
+      "music_quiz2": "Wgrox msij zs erjereryх ockirxf",
+      "music_quiz3": "Zko fxoxkz ziruх ziruх zsxw zsrw",
+      "music_quiz4": "Wgrox ho cifruv okjxc"
     }
   },
   "scene": {

--- a/packages/quiz_core/lib/i18n/strings.g.dart
+++ b/packages/quiz_core/lib/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 3
-/// Strings: 776 (258 per locale)
+/// Strings: 806 (268 per locale)
 ///
-/// Built on 2026-04-23 at 10:53 UTC
+/// Built on 2026-05-07 at 02:36 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/packages/quiz_core/lib/i18n/strings_en.g.dart
+++ b/packages/quiz_core/lib/i18n/strings_en.g.dart
@@ -339,6 +339,7 @@ class _TranslationsPlayCategoryLabelEn extends TranslationsPlayCategoryLabelJa {
 	@override String get comic => 'Manga App';
 	@override String get todo => 'TODO App';
 	@override String get matching => 'Matching';
+	@override String get music => 'Music';
 }
 
 // Path: play.categoryDescription
@@ -361,6 +362,7 @@ class _TranslationsPlayCategoryDescriptionEn extends TranslationsPlayCategoryDes
 	@override String get comic => 'Master manga app operations';
 	@override String get todo => 'Experience task management app UI/UX';
 	@override String get matching => 'Experience matching app UI/UX';
+	@override String get music => 'Experience music player UI/UX';
 }
 
 // Path: play.stageTitle
@@ -422,6 +424,10 @@ class _TranslationsPlayStageTitleEn extends TranslationsPlayStageTitleJa {
 	@override String get matching_quiz2 => 'Not quite your type... skip them';
 	@override String get matching_quiz3 => 'View the second photo';
 	@override String get matching_quiz4 => 'Your destiny! Send a Super Like';
+	@override String get music_quiz1 => 'Skip to the next song';
+	@override String get music_quiz2 => 'Minimize the player';
+	@override String get music_quiz3 => 'Set to 1-song repeat';
+	@override String get music_quiz4 => 'Show the lyrics';
 }
 
 // Path: play.stageDescription
@@ -483,6 +489,10 @@ class _TranslationsPlayStageDescriptionEn extends TranslationsPlayStageDescripti
 	@override String get matching_quiz2 => 'Swipe left to skip';
 	@override String get matching_quiz3 => 'Tap the right half of the profile card to see the second photo';
 	@override String get matching_quiz4 => 'Swipe up to send a Super Like';
+	@override String get music_quiz1 => 'Swipe left on the album art or tap the skip button to go to the next song';
+	@override String get music_quiz2 => 'Swipe down on the full-screen player to minimize it';
+	@override String get music_quiz3 => 'Tap the repeat button twice to set 1-song repeat';
+	@override String get music_quiz4 => 'Swipe up the lyrics panel at the bottom of the screen';
 }
 
 // Path: scene.greeting
@@ -649,6 +659,7 @@ extension on TranslationsEn {
 			'play.categoryLabel.comic' => 'Manga App',
 			'play.categoryLabel.todo' => 'TODO App',
 			'play.categoryLabel.matching' => 'Matching',
+			'play.categoryLabel.music' => 'Music',
 			'play.categoryDescription.shopping' => 'Experience e-commerce UI/UX',
 			'play.categoryDescription.chat' => 'Experience messaging app UI/UX',
 			'play.categoryDescription.streaming' => 'Experience video app UI/UX',
@@ -662,6 +673,7 @@ extension on TranslationsEn {
 			'play.categoryDescription.comic' => 'Master manga app operations',
 			'play.categoryDescription.todo' => 'Experience task management app UI/UX',
 			'play.categoryDescription.matching' => 'Experience matching app UI/UX',
+			'play.categoryDescription.music' => 'Experience music player UI/UX',
 			'play.stageTitle.shopping_quiz1' => 'Buy 2 Waters',
 			'play.stageTitle.shopping_quiz2' => 'Complete Checkout',
 			'play.stageTitle.shopping_quiz3' => 'Reorder Recent Purchase',
@@ -714,6 +726,10 @@ extension on TranslationsEn {
 			'play.stageTitle.matching_quiz2' => 'Not quite your type... skip them',
 			'play.stageTitle.matching_quiz3' => 'View the second photo',
 			'play.stageTitle.matching_quiz4' => 'Your destiny! Send a Super Like',
+			'play.stageTitle.music_quiz1' => 'Skip to the next song',
+			'play.stageTitle.music_quiz2' => 'Minimize the player',
+			'play.stageTitle.music_quiz3' => 'Set to 1-song repeat',
+			'play.stageTitle.music_quiz4' => 'Show the lyrics',
 			'play.stageDescription.shopping_quiz1' => 'Add 2 waters to the cart and purchase on the e-commerce site',
 			'play.stageDescription.shopping_quiz2' => 'Complete 3 steps: address, payment method, and order confirmation',
 			'play.stageDescription.shopping_quiz3' => 'Reorder the most recently purchased item from order history',
@@ -766,6 +782,10 @@ extension on TranslationsEn {
 			'play.stageDescription.matching_quiz2' => 'Swipe left to skip',
 			'play.stageDescription.matching_quiz3' => 'Tap the right half of the profile card to see the second photo',
 			'play.stageDescription.matching_quiz4' => 'Swipe up to send a Super Like',
+			'play.stageDescription.music_quiz1' => 'Swipe left on the album art or tap the skip button to go to the next song',
+			'play.stageDescription.music_quiz2' => 'Swipe down on the full-screen player to minimize it',
+			'play.stageDescription.music_quiz3' => 'Tap the repeat button twice to set 1-song repeat',
+			'play.stageDescription.music_quiz4' => 'Swipe up the lyrics panel at the bottom of the screen',
 			'scene.greeting.sunriseMorning' => 'Good morning',
 			'scene.greeting.sunnyDay' => 'Beautiful day today',
 			'scene.greeting.cloudyDay' => 'A cloudy day',

--- a/packages/quiz_core/lib/i18n/strings_ja.g.dart
+++ b/packages/quiz_core/lib/i18n/strings_ja.g.dart
@@ -568,6 +568,9 @@ class TranslationsPlayCategoryLabelJa {
 
 	/// ja: 'マッチング'
 	String get matching => 'マッチング';
+
+	/// ja: '音楽'
+	String get music => '音楽';
 }
 
 // Path: play.categoryDescription
@@ -616,6 +619,9 @@ class TranslationsPlayCategoryDescriptionJa {
 
 	/// ja: 'マッチングアプリのUI/UXを体験しよう'
 	String get matching => 'マッチングアプリのUI/UXを体験しよう';
+
+	/// ja: '音楽プレイヤーのUI/UXを体験しよう'
+	String get music => '音楽プレイヤーのUI/UXを体験しよう';
 }
 
 // Path: play.stageTitle
@@ -781,6 +787,18 @@ class TranslationsPlayStageTitleJa {
 
 	/// ja: '運命の出会い！『超いいね』を送ろう'
 	String get matching_quiz4 => '運命の出会い！『超いいね』を送ろう';
+
+	/// ja: '次の曲に進めよう'
+	String get music_quiz1 => '次の曲に進めよう';
+
+	/// ja: '再生画面を収納しよう'
+	String get music_quiz2 => '再生画面を収納しよう';
+
+	/// ja: '1曲リピートに設定しよう'
+	String get music_quiz3 => '1曲リピートに設定しよう';
+
+	/// ja: '歌詞を表示しよう'
+	String get music_quiz4 => '歌詞を表示しよう';
 }
 
 // Path: play.stageDescription
@@ -946,6 +964,18 @@ class TranslationsPlayStageDescriptionJa {
 
 	/// ja: '上にスワイプして超いいねを送ってください'
 	String get matching_quiz4 => '上にスワイプして超いいねを送ってください';
+
+	/// ja: 'アルバムアートを左にスワイプするか、スキップボタンで次の曲に進んでください'
+	String get music_quiz1 => 'アルバムアートを左にスワイプするか、スキップボタンで次の曲に進んでください';
+
+	/// ja: '全画面プレイヤーを下にスワイプしてミニプレイヤーに収納してください'
+	String get music_quiz2 => '全画面プレイヤーを下にスワイプしてミニプレイヤーに収納してください';
+
+	/// ja: 'リピートボタンを2回タップして1曲リピート状態にしてください'
+	String get music_quiz3 => 'リピートボタンを2回タップして1曲リピート状態にしてください';
+
+	/// ja: '画面下部の歌詞パネルを上にスワイプして引き上げてください'
+	String get music_quiz4 => '画面下部の歌詞パネルを上にスワイプして引き上げてください';
 }
 
 // Path: scene.greeting
@@ -1174,6 +1204,7 @@ extension on Translations {
 			'play.categoryLabel.comic' => '漫画アプリ',
 			'play.categoryLabel.todo' => 'タスク管理',
 			'play.categoryLabel.matching' => 'マッチング',
+			'play.categoryLabel.music' => '音楽',
 			'play.categoryDescription.shopping' => 'ECサイトのUI/UXを体験しよう',
 			'play.categoryDescription.chat' => 'メッセージアプリのUI/UXを体験しよう',
 			'play.categoryDescription.streaming' => '動画アプリのUI/UXを体験しよう',
@@ -1187,6 +1218,7 @@ extension on Translations {
 			'play.categoryDescription.comic' => '漫画アプリの操作をマスターしよう',
 			'play.categoryDescription.todo' => 'TODOアプリのUI/UXを体験しよう',
 			'play.categoryDescription.matching' => 'マッチングアプリのUI/UXを体験しよう',
+			'play.categoryDescription.music' => '音楽プレイヤーのUI/UXを体験しよう',
 			'play.stageTitle.shopping_quiz1' => '水を2つ買おう',
 			'play.stageTitle.shopping_quiz2' => '購入手続きを完了しよう',
 			'play.stageTitle.shopping_quiz3' => '直近の注文を再注文しよう',
@@ -1239,6 +1271,10 @@ extension on Translations {
 			'play.stageTitle.matching_quiz2' => '気が合わなそう……スキップしよう',
 			'play.stageTitle.matching_quiz3' => '2枚目の写真を見てみよう',
 			'play.stageTitle.matching_quiz4' => '運命の出会い！『超いいね』を送ろう',
+			'play.stageTitle.music_quiz1' => '次の曲に進めよう',
+			'play.stageTitle.music_quiz2' => '再生画面を収納しよう',
+			'play.stageTitle.music_quiz3' => '1曲リピートに設定しよう',
+			'play.stageTitle.music_quiz4' => '歌詞を表示しよう',
 			'play.stageDescription.shopping_quiz1' => 'ECサイトで水を2つカートに入れて購入してください',
 			'play.stageDescription.shopping_quiz2' => '住所入力・支払い方法選択・注文確認の3ステップを完了してください',
 			'play.stageDescription.shopping_quiz3' => '注文履歴から直近で注文した商品をもう一度購入してください',
@@ -1291,6 +1327,10 @@ extension on Translations {
 			'play.stageDescription.matching_quiz2' => '左にスワイプしてスキップしてください',
 			'play.stageDescription.matching_quiz3' => 'プロフィールカードの右半分をタップして2枚目の写真を見てください',
 			'play.stageDescription.matching_quiz4' => '上にスワイプして超いいねを送ってください',
+			'play.stageDescription.music_quiz1' => 'アルバムアートを左にスワイプするか、スキップボタンで次の曲に進んでください',
+			'play.stageDescription.music_quiz2' => '全画面プレイヤーを下にスワイプしてミニプレイヤーに収納してください',
+			'play.stageDescription.music_quiz3' => 'リピートボタンを2回タップして1曲リピート状態にしてください',
+			'play.stageDescription.music_quiz4' => '画面下部の歌詞パネルを上にスワイプして引き上げてください',
 			'scene.greeting.sunriseMorning' => 'おはようございます',
 			'scene.greeting.sunnyDay' => '今日もいい天気',
 			'scene.greeting.cloudyDay' => '曇り空の一日',

--- a/packages/quiz_core/lib/i18n/strings_xx.g.dart
+++ b/packages/quiz_core/lib/i18n/strings_xx.g.dart
@@ -339,6 +339,7 @@ class _TranslationsPlayCategoryLabelXx extends TranslationsPlayCategoryLabelJa {
 	@override String get comic => '漫画アプリ';
 	@override String get todo => 'タスク管理';
 	@override String get matching => 'Ekzuyrjp';
+	@override String get music => 'Tnwru';
 }
 
 // Path: play.categoryDescription
@@ -361,6 +362,7 @@ class _TranslationsPlayCategoryDescriptionXx extends TranslationsPlayCategoryDes
 	@override String get comic => '漫画アプリの操作をマスターしよう';
 	@override String get todo => 'ZSMS koo HR/HT xtoxfrxjux';
 	@override String get matching => 'Ekzuyrjp koo HR/HT xtoxfrxjux';
+	@override String get music => 'Tnwru ockirxf HR/HT xtoxfrxjux';
 }
 
 // Path: play.stageTitle
@@ -422,6 +424,10 @@ class _TranslationsPlayStageTitleXx extends TranslationsPlayStageTitleJa {
 	@override String get matching_quiz2 => 'Jsz lhrzx ishf zioх... waро zyxe';
 	@override String get matching_quiz3 => 'Nrxg zyx wxusjm oyszs';
 	@override String get matching_quiz4 => 'Ishf mxwzrji! Wxjm k Whoef Crax';
+	@override String get music_quiz1 => 'Waро zs jxtz wsjp';
+	@override String get music_quiz2 => 'Mrjreryx ockirxf';
+	@override String get music_quiz3 => 'Wxz 1-wsjp fxoxkz';
+	@override String get music_quiz4 => 'Wysw cifruv';
 }
 
 // Path: play.stageDescription
@@ -479,6 +485,10 @@ class _TranslationsPlayStageDescriptionXx extends TranslationsPlayStageDescripti
 	@override String get matching_quiz2 => 'Wgrox cxbz zs waро';
 	@override String get matching_quiz3 => 'Zko zyx frpyz ykcb sb zyx ofsbrcх ukfm zs wxx zyx wxusjm oyszs';
 	@override String get matching_quiz4 => 'Wgrox ho zs wxjm k Whoef Crax';
+	@override String get music_quiz1 => 'Wgrox cxbz sj kcbhe kfz sf zko waро';
+	@override String get music_quiz2 => 'Wgrox msij zs erjereryх ockirxf';
+	@override String get music_quiz3 => 'Zko fxoxkz ziruх ziruх zsxw zsrw';
+	@override String get music_quiz4 => 'Wgrox ho cifruv okjxc';
 }
 
 // Path: scene.greeting
@@ -645,6 +655,7 @@ extension on TranslationsXx {
 			'play.categoryLabel.comic' => '漫画アプリ',
 			'play.categoryLabel.todo' => 'タスク管理',
 			'play.categoryLabel.matching' => 'Ekzuyrjp',
+			'play.categoryLabel.music' => 'Tnwru',
 			'play.categoryDescription.shopping' => 'ECサイトのUI/UXを体験しよう',
 			'play.categoryDescription.chat' => 'メッセージアプリのUI/UXを体験しよう',
 			'play.categoryDescription.streaming' => '動画アプリのUI/UXを体験しよう',
@@ -658,6 +669,7 @@ extension on TranslationsXx {
 			'play.categoryDescription.comic' => '漫画アプリの操作をマスターしよう',
 			'play.categoryDescription.todo' => 'ZSMS koo HR/HT xtoxfrxjux',
 			'play.categoryDescription.matching' => 'Ekzuyrjp koo HR/HT xtoxfrxjux',
+			'play.categoryDescription.music' => 'Tnwru ockirxf HR/HT xtoxfrxjux',
 			'play.stageTitle.shopping_quiz1' => '水を2つ買おう',
 			'play.stageTitle.shopping_quiz2' => '購入手続きを完了しよう',
 			'play.stageTitle.shopping_quiz3' => '直近の注文を再注文しよう',
@@ -710,6 +722,10 @@ extension on TranslationsXx {
 			'play.stageTitle.matching_quiz2' => 'Jsz lhrzx ishf zioх... waро zyxe',
 			'play.stageTitle.matching_quiz3' => 'Nrxg zyx wxusjm oyszs',
 			'play.stageTitle.matching_quiz4' => 'Ishf mxwzrji! Wxjm k Whoef Crax',
+			'play.stageTitle.music_quiz1' => 'Waро zs jxtz wsjp',
+			'play.stageTitle.music_quiz2' => 'Mrjreryx ockirxf',
+			'play.stageTitle.music_quiz3' => 'Wxz 1-wsjp fxoxkz',
+			'play.stageTitle.music_quiz4' => 'Wysw cifruv',
 			'play.stageDescription.shopping_quiz1' => 'ECサイトで水を2つカートに入れて購入してください',
 			'play.stageDescription.shopping_quiz2' => '住所入力・支払い方法選択・注文確認の3ステップを完了してください',
 			'play.stageDescription.shopping_quiz3' => '注文履歴から直近で注文した商品をもう一度購入してください',
@@ -758,6 +774,10 @@ extension on TranslationsXx {
 			'play.stageDescription.matching_quiz2' => 'Wgrox cxbz zs waро',
 			'play.stageDescription.matching_quiz3' => 'Zko zyx frpyz ykcb sb zyx ofsbrcх ukfm zs wxx zyx wxusjm oyszs',
 			'play.stageDescription.matching_quiz4' => 'Wgrox ho zs wxjm k Whoef Crax',
+			'play.stageDescription.music_quiz1' => 'Wgrox cxbz sj kcbhe kfz sf zko waро',
+			'play.stageDescription.music_quiz2' => 'Wgrox msij zs erjereryх ockirxf',
+			'play.stageDescription.music_quiz3' => 'Zko fxoxkz ziruх ziruх zsxw zsrw',
+			'play.stageDescription.music_quiz4' => 'Wgrox ho cifruv okjxc',
 			'scene.greeting.sunriseMorning' => 'おはようございます',
 			'scene.greeting.sunnyDay' => '今日もいい天気',
 			'scene.greeting.cloudyDay' => '曇り空の一日',

--- a/packages/quiz_core/lib/quiz_core.dart
+++ b/packages/quiz_core/lib/quiz_core.dart
@@ -9,6 +9,7 @@ export 'src/theme/comic_app_theme.dart';
 export 'src/theme/mail_app_theme.dart';
 export 'src/theme/map_app_theme.dart';
 export 'src/theme/matching_app_theme.dart';
+export 'src/theme/music_app_theme.dart';
 export 'src/theme/news_app_theme.dart';
 export 'src/theme/nanto_nack_theme_extension.dart';
 export 'src/theme/payment_app_theme.dart';

--- a/packages/quiz_core/lib/src/theme/app_theme.dart
+++ b/packages/quiz_core/lib/src/theme/app_theme.dart
@@ -8,6 +8,7 @@ import 'package:quiz_core/src/theme/payment_app_theme.dart';
 import 'package:quiz_core/src/theme/shopping_app_theme.dart';
 import 'package:quiz_core/src/theme/mail_app_theme.dart';
 import 'package:quiz_core/src/theme/matching_app_theme.dart';
+import 'package:quiz_core/src/theme/music_app_theme.dart';
 import 'package:quiz_core/src/theme/news_app_theme.dart';
 import 'package:quiz_core/src/theme/sns_app_theme.dart';
 import 'package:quiz_core/src/theme/streaming_app_theme.dart';
@@ -37,6 +38,7 @@ abstract final class AppTheme {
         MailAppTheme.light,
         MapAppTheme.light,
         MatchingAppTheme.light,
+        MusicAppTheme.light,
         NewsAppTheme.light,
         PaymentAppTheme.light,
         ShoppingAppTheme.light,
@@ -69,6 +71,7 @@ abstract final class AppTheme {
         MailAppTheme.dark,
         MapAppTheme.dark,
         MatchingAppTheme.dark,
+        MusicAppTheme.dark,
         NewsAppTheme.dark,
         PaymentAppTheme.dark,
         ShoppingAppTheme.dark,

--- a/packages/quiz_core/lib/src/theme/music_app_theme.dart
+++ b/packages/quiz_core/lib/src/theme/music_app_theme.dart
@@ -1,0 +1,132 @@
+import 'package:flutter/material.dart';
+
+/// 音楽プレイヤー（YouTube Music 風）アプリ画面のカスタムカラーを ThemeExtension として定義する。
+@immutable
+class MusicAppTheme extends ThemeExtension<MusicAppTheme> {
+  const MusicAppTheme({
+    required this.playerBackground,
+    required this.appBarBackground,
+    required this.cardBackground,
+    required this.brandColor,
+    required this.accentColor,
+    required this.primaryTextColor,
+    required this.subTextColor,
+    required this.activeColor,
+    required this.inactiveColor,
+    required this.highlightBorderColor,
+    required this.miniPlayerBackground,
+  });
+
+  /// プレイヤー背景色
+  final Color playerBackground;
+
+  /// AppBar 背景色
+  final Color appBarBackground;
+
+  /// カード背景色
+  final Color cardBackground;
+
+  /// ブランドカラー（YouTube Music 風サーモンレッド）
+  final Color brandColor;
+
+  /// アクセントカラー（ピンクパープル）
+  final Color accentColor;
+
+  /// 主要テキスト色
+  final Color primaryTextColor;
+
+  /// サブテキスト色
+  final Color subTextColor;
+
+  /// アクティブ状態色
+  final Color activeColor;
+
+  /// 非アクティブ状態色
+  final Color inactiveColor;
+
+  /// ヒントハイライトボーダー色
+  final Color highlightBorderColor;
+
+  /// ミニプレイヤー背景色
+  final Color miniPlayerBackground;
+
+  static const light = MusicAppTheme(
+    playerBackground: Color(0xFF1A0533),
+    appBarBackground: Color(0xFF120024),
+    cardBackground: Color(0xFF2D1B47),
+    brandColor: Color(0xFFFF6B6B),
+    accentColor: Color(0xFFE040FB),
+    primaryTextColor: Color(0xFFFFFFFF),
+    subTextColor: Color(0xFFB39DDB),
+    activeColor: Color(0xFFE040FB),
+    inactiveColor: Color(0xFF7E57C2),
+    highlightBorderColor: Color(0xFFFFEB3B),
+    miniPlayerBackground: Color(0xFF2D1B47),
+  );
+
+  static const dark = MusicAppTheme(
+    playerBackground: Color(0xFF0D0015),
+    appBarBackground: Color(0xFF080010),
+    cardBackground: Color(0xFF1A0533),
+    brandColor: Color(0xFFFF6B6B),
+    accentColor: Color(0xFFCE93D8),
+    primaryTextColor: Color(0xFFFFFFFF),
+    subTextColor: Color(0xFF9575CD),
+    activeColor: Color(0xFFCE93D8),
+    inactiveColor: Color(0xFF5E35B1),
+    highlightBorderColor: Color(0xFFFFEB3B),
+    miniPlayerBackground: Color(0xFF1A0533),
+  );
+
+  @override
+  MusicAppTheme copyWith({
+    Color? playerBackground,
+    Color? appBarBackground,
+    Color? cardBackground,
+    Color? brandColor,
+    Color? accentColor,
+    Color? primaryTextColor,
+    Color? subTextColor,
+    Color? activeColor,
+    Color? inactiveColor,
+    Color? highlightBorderColor,
+    Color? miniPlayerBackground,
+  }) {
+    return MusicAppTheme(
+      playerBackground: playerBackground ?? this.playerBackground,
+      appBarBackground: appBarBackground ?? this.appBarBackground,
+      cardBackground: cardBackground ?? this.cardBackground,
+      brandColor: brandColor ?? this.brandColor,
+      accentColor: accentColor ?? this.accentColor,
+      primaryTextColor: primaryTextColor ?? this.primaryTextColor,
+      subTextColor: subTextColor ?? this.subTextColor,
+      activeColor: activeColor ?? this.activeColor,
+      inactiveColor: inactiveColor ?? this.inactiveColor,
+      highlightBorderColor: highlightBorderColor ?? this.highlightBorderColor,
+      miniPlayerBackground: miniPlayerBackground ?? this.miniPlayerBackground,
+    );
+  }
+
+  @override
+  MusicAppTheme lerp(covariant MusicAppTheme? other, double t) {
+    if (other == null) return this;
+    return MusicAppTheme(
+      playerBackground:
+          Color.lerp(playerBackground, other.playerBackground, t)!,
+      appBarBackground:
+          Color.lerp(appBarBackground, other.appBarBackground, t)!,
+      cardBackground: Color.lerp(cardBackground, other.cardBackground, t)!,
+      brandColor: Color.lerp(brandColor, other.brandColor, t)!,
+      accentColor: Color.lerp(accentColor, other.accentColor, t)!,
+      primaryTextColor:
+          Color.lerp(primaryTextColor, other.primaryTextColor, t)!,
+      subTextColor: Color.lerp(subTextColor, other.subTextColor, t)!,
+      activeColor: Color.lerp(activeColor, other.activeColor, t)!,
+      inactiveColor: Color.lerp(inactiveColor, other.inactiveColor, t)!,
+      highlightBorderColor:
+          Color.lerp(highlightBorderColor, other.highlightBorderColor, t)!,
+      miniPlayerBackground:
+          Color.lerp(miniPlayerBackground, other.miniPlayerBackground, t)!,
+    );
+  }
+}

--- a/packages/quiz_core/lib/src/theme/music_app_theme.dart
+++ b/packages/quiz_core/lib/src/theme/music_app_theme.dart
@@ -15,6 +15,7 @@ class MusicAppTheme extends ThemeExtension<MusicAppTheme> {
     required this.inactiveColor,
     required this.highlightBorderColor,
     required this.miniPlayerBackground,
+    required this.onAlbumColor,
   });
 
   /// プレイヤー背景色
@@ -50,6 +51,9 @@ class MusicAppTheme extends ThemeExtension<MusicAppTheme> {
   /// ミニプレイヤー背景色
   final Color miniPlayerBackground;
 
+  /// アルバムカラー背景上のアイコン・テキスト色
+  final Color onAlbumColor;
+
   static const light = MusicAppTheme(
     playerBackground: Color(0xFF1A0533),
     appBarBackground: Color(0xFF120024),
@@ -62,6 +66,7 @@ class MusicAppTheme extends ThemeExtension<MusicAppTheme> {
     inactiveColor: Color(0xFF7E57C2),
     highlightBorderColor: Color(0xFFFFEB3B),
     miniPlayerBackground: Color(0xFF2D1B47),
+    onAlbumColor: Color(0xFFFFFFFF),
   );
 
   static const dark = MusicAppTheme(
@@ -76,6 +81,7 @@ class MusicAppTheme extends ThemeExtension<MusicAppTheme> {
     inactiveColor: Color(0xFF5E35B1),
     highlightBorderColor: Color(0xFFFFEB3B),
     miniPlayerBackground: Color(0xFF1A0533),
+    onAlbumColor: Color(0xFFFFFFFF),
   );
 
   @override
@@ -91,6 +97,7 @@ class MusicAppTheme extends ThemeExtension<MusicAppTheme> {
     Color? inactiveColor,
     Color? highlightBorderColor,
     Color? miniPlayerBackground,
+    Color? onAlbumColor,
   }) {
     return MusicAppTheme(
       playerBackground: playerBackground ?? this.playerBackground,
@@ -104,6 +111,7 @@ class MusicAppTheme extends ThemeExtension<MusicAppTheme> {
       inactiveColor: inactiveColor ?? this.inactiveColor,
       highlightBorderColor: highlightBorderColor ?? this.highlightBorderColor,
       miniPlayerBackground: miniPlayerBackground ?? this.miniPlayerBackground,
+      onAlbumColor: onAlbumColor ?? this.onAlbumColor,
     );
   }
 
@@ -127,6 +135,7 @@ class MusicAppTheme extends ThemeExtension<MusicAppTheme> {
           Color.lerp(highlightBorderColor, other.highlightBorderColor, t)!,
       miniPlayerBackground:
           Color.lerp(miniPlayerBackground, other.miniPlayerBackground, t)!,
+      onAlbumColor: Color.lerp(onAlbumColor, other.onAlbumColor, t)!,
     );
   }
 }

--- a/packages/quiz_core/lib/src/theme/nanto_nack_theme_extension.dart
+++ b/packages/quiz_core/lib/src/theme/nanto_nack_theme_extension.dart
@@ -37,6 +37,8 @@ class NantoNackThemeExtension
     required this.todoCategoryContainerColor,
     required this.matchingCategoryColor,
     required this.matchingCategoryContainerColor,
+    required this.musicCategoryColor,
+    required this.musicCategoryContainerColor,
   });
 
   /// 連続プレイ日数（ストリーク）のアクセントカラー
@@ -128,6 +130,12 @@ class NantoNackThemeExtension
   /// マッチングカテゴリーカードの背景コンテナカラー
   final Color matchingCategoryContainerColor;
 
+  /// 音楽カテゴリーのブランドカラー（YouTube Music風パープル）
+  final Color musicCategoryColor;
+
+  /// 音楽カテゴリーカードの背景コンテナカラー
+  final Color musicCategoryContainerColor;
+
   /// ライトテーマ用デフォルト値
   static const light = NantoNackThemeExtension(
     streakColor: Color(0xFFE65100),
@@ -160,6 +168,8 @@ class NantoNackThemeExtension
     todoCategoryContainerColor: Color(0xFFDEEBFF),
     matchingCategoryColor: Color(0xFFE91E63),
     matchingCategoryContainerColor: Color(0xFFFCE4EC),
+    musicCategoryColor: Color(0xFF7B1FA2),
+    musicCategoryContainerColor: Color(0xFFF3E5F5),
   );
 
   /// マップのピンカラーリスト（colorSeed インデックスに対応）
@@ -206,6 +216,8 @@ class NantoNackThemeExtension
     todoCategoryContainerColor: Color(0xFF0C1C3A),
     matchingCategoryColor: Color(0xFFF06292),
     matchingCategoryContainerColor: Color(0xFF4A0B2C),
+    musicCategoryColor: Color(0xFFCE93D8),
+    musicCategoryContainerColor: Color(0xFF2D0F3A),
   );
 
   @override
@@ -240,6 +252,8 @@ class NantoNackThemeExtension
     Color? todoCategoryContainerColor,
     Color? matchingCategoryColor,
     Color? matchingCategoryContainerColor,
+    Color? musicCategoryColor,
+    Color? musicCategoryContainerColor,
   }) {
     return NantoNackThemeExtension(
       streakColor: streakColor ?? this.streakColor,
@@ -290,6 +304,9 @@ class NantoNackThemeExtension
           matchingCategoryColor ?? this.matchingCategoryColor,
       matchingCategoryContainerColor:
           matchingCategoryContainerColor ?? this.matchingCategoryContainerColor,
+      musicCategoryColor: musicCategoryColor ?? this.musicCategoryColor,
+      musicCategoryContainerColor:
+          musicCategoryContainerColor ?? this.musicCategoryContainerColor,
     );
   }
 
@@ -404,6 +421,13 @@ class NantoNackThemeExtension
       matchingCategoryContainerColor: Color.lerp(
         matchingCategoryContainerColor,
         other.matchingCategoryContainerColor,
+        t,
+      )!,
+      musicCategoryColor:
+          Color.lerp(musicCategoryColor, other.musicCategoryColor, t)!,
+      musicCategoryContainerColor: Color.lerp(
+        musicCategoryContainerColor,
+        other.musicCategoryContainerColor,
         t,
       )!,
     );

--- a/packages/quizzes/music/analysis_options.yaml
+++ b/packages/quizzes/music/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: ../../../analysis_options.yaml

--- a/packages/quizzes/music/assets/i18n/en.i18n.json
+++ b/packages/quizzes/music/assets/i18n/en.i18n.json
@@ -1,0 +1,79 @@
+{
+  "quiz1": {
+    "missionText": "Don't like this song? Try skipping to the next one",
+    "insight": {
+      "title": "How did you skip to the next song?",
+      "subtitle": "The swipe-to-change feeling",
+      "swipeTitle": "Left swipe on album art",
+      "swipeDesc": "Swiping left on album artwork to go to the next song feels just like flipping through gallery photos. The visual card UI intuitively signals that it can be 'swiped'.",
+      "skipTitle": "The skip button (⏭) meaning",
+      "skipDesc": "The '▶▶|' symbol from the cassette era means 'skip to next track'. Its placement next to the play button (on the right) has become a global standard.",
+      "gestureTitle": "Dual operation: gesture and button",
+      "gestureDesc": "Offering the same function (song change) through both swipe and tap lets users choose their preferred input method — a 'multiple input paths' principle of mobile UX."
+    }
+  },
+  "quiz2": {
+    "missionText": "Want to browse for a song? Minimize the player to go back",
+    "insight": {
+      "title": "How did you know to drag the screen down?",
+      "subtitle": "The sheet UI 'pull-down' pattern",
+      "dragTitle": "Drag down to 'close'",
+      "dragDesc": "Dragging down to minimize the full-screen player became popular through Spotify and Apple Music on iOS. 'Pull down = close/store' is now a shared concept among smartphone users.",
+      "miniTitle": "Music continues in mini player",
+      "miniDesc": "Closing the full-screen view doesn't stop the music — playback continues in the mini player at the bottom. This 'keep doing other things while listening' UX pattern is widely used.",
+      "notchTitle": "The drag indicator (notch)",
+      "notchDesc": "The thin horizontal bar at the top of the sheet signals 'this UI can be dragged'. Small but visually significant, it prompts users to try pulling."
+    }
+  },
+  "quiz3": {
+    "missionText": "This song is amazing! Set it to repeat just this one song",
+    "insight": {
+      "title": "Did you figure out the repeat button?",
+      "subtitle": "The 3-state repeat button",
+      "repeatTitle": "3 states in one button",
+      "repeatDesc": "🔁 (loop all) → 🔂 (loop one) → off: three states cycle through one button. The '1' badge is what distinguishes 'loop one' from 'loop all' — a clever symbol extension.",
+      "iconTitle": "Circular arrows + '1'",
+      "iconDesc": "Two circular arrows mean 'repeat', but adding '1' changes the meaning to 'repeat this one track'. A great example of using a modifier number to expand meaning.",
+      "tapTitle": "Tap to cycle through states",
+      "tapDesc": "Repeatedly tapping the same button to cycle through states — the 'cycle operation' UX pattern — is used in many apps beyond music players."
+    }
+  },
+  "quiz4": {
+    "missionText": "What are they singing? Try checking the lyrics",
+    "insight": {
+      "title": "How did you pull up the lyrics panel?",
+      "subtitle": "The bottom sheet 'pull-up' pattern",
+      "dragTitle": "Pull up the bottom sheet",
+      "dragDesc": "Swiping up a partially visible panel at the bottom of the screen became mainstream through Google Maps' place info sheet. The physical sensation of 'grab and pull up' is directly reflected in the UI.",
+      "handleTitle": "The drag handle says 'I can be dragged'",
+      "handleDesc": "The thin bar at the top of the panel signals that this UI can be dragged up and down. It's a classic affordance — using shape instead of text to communicate interactivity.",
+      "lyricsTitle": "Lyrics combined with scrolling",
+      "lyricsDesc": "Having lyrics scroll inside the pulled-up sheet answers the expectation of 'once pulled up, I can read as much as I want' — a clean separation of sheet state and content state."
+    }
+  },
+  "common": {
+    "appTitle": "MusicHub",
+    "homeTab": "Home",
+    "libraryTab": "Library",
+    "searchTab": "Search",
+    "likeButton": "Like",
+    "moreButton": "More",
+    "playlistTitle": "My Playlist",
+    "songCount": "{count} songs",
+    "@songCount": { "param": "count" },
+    "lyrics": "Lyrics",
+    "lyricsNotAvailable": "No lyrics available",
+    "quitConfirmTitle": "Quit Game?",
+    "quitConfirmMessage": "Your current game will end.",
+    "continueButton": "Continue",
+    "quitButton": "Quit"
+  },
+  "songs": {
+    "song1Title": "Starlight Drive",
+    "song1Artist": "The Cosmic Band",
+    "song1Lyrics": "Driving down the starlit road\nFeeling free, no heavy load\nNeon lights and city dreams\nNothing's ever what it seems\n\nRide with me through the night\nEverything will be alright\nStarlight drive, starlight drive\nKeep us feeling so alive",
+    "song2Title": "Ocean Waves",
+    "song2Artist": "Blue Horizon",
+    "song2Lyrics": "The ocean calls my name tonight\nWaves of blue in morning light\nSalt and sea and endless sky\nWatching seagulls as they fly\n\nLet the tide wash away\nAll the worries of the day\nOcean waves, ocean waves\nFind the peace that silence saves"
+  }
+}

--- a/packages/quizzes/music/assets/i18n/en.i18n.json
+++ b/packages/quizzes/music/assets/i18n/en.i18n.json
@@ -66,7 +66,9 @@
     "quitConfirmTitle": "Quit Game?",
     "quitConfirmMessage": "Your current game will end.",
     "continueButton": "Continue",
-    "quitButton": "Quit"
+    "quitButton": "Quit",
+    "mockCurrentTime": "1:12",
+    "mockDuration": "3:45"
   },
   "songs": {
     "song1Title": "Starlight Drive",

--- a/packages/quizzes/music/assets/i18n/ja.i18n.json
+++ b/packages/quizzes/music/assets/i18n/ja.i18n.json
@@ -66,7 +66,9 @@
     "quitConfirmTitle": "ゲームを中断しますか？",
     "quitConfirmMessage": "プレイ中のゲームを終了します。",
     "continueButton": "続ける",
-    "quitButton": "終了する"
+    "quitButton": "終了する",
+    "mockCurrentTime": "1:12",
+    "mockDuration": "3:45"
   },
   "songs": {
     "song1Title": "Starlight Drive",

--- a/packages/quizzes/music/assets/i18n/ja.i18n.json
+++ b/packages/quizzes/music/assets/i18n/ja.i18n.json
@@ -1,0 +1,79 @@
+{
+  "quiz1": {
+    "missionText": "この曲じゃないなぁ。次の曲に進めてみよう",
+    "insight": {
+      "title": "なぜ次の曲に進めたの？",
+      "subtitle": "スワイプで曲を変える感覚",
+      "swipeTitle": "ジャケ写の左スワイプ",
+      "swipeDesc": "アルバムアートを左にスワイプすると次の曲に進む操作は、スマホのギャラリー画像送りと同じ感覚。視覚的なカードUIが「送れる」ことを直感的に示している。",
+      "skipTitle": "スキップボタン（⏭）の意味",
+      "skipDesc": "カセットデッキの時代から続く「▶▶|」記号は、次のトラックへのスキップを意味する。音楽プレイヤー共通の配置（再生ボタンの右隣）が世界標準となっている。",
+      "gestureTitle": "ジェスチャーとボタンの二重操作",
+      "gestureDesc": "同じ機能（曲送り）をスワイプとタップの両方で実現することで、ユーザーは好みの操作方法を選べる。これはモバイルUXの「複数の入力経路」の原則だ。"
+    }
+  },
+  "quiz2": {
+    "missionText": "曲を探しに戻りたい。再生画面を小さくして収納しよう",
+    "insight": {
+      "title": "なぜ画面を下に引けるとわかった？",
+      "subtitle": "シートUIの「引き下げ」パターン",
+      "dragTitle": "下ドラッグで「閉じる」",
+      "dragDesc": "全画面から下にドラッグして画面を小さくする操作は、iOSのSpotify・Apple Musicで定着した。「引き下げ = 閉じる/収納」の概念がスマホユーザーの共通認識となっている。",
+      "miniTitle": "ミニプレイヤーで音楽を継続",
+      "miniDesc": "全画面を閉じても音楽が止まらず、画面下部のミニプレイヤーで再生が続く。この「ながら操作」のUXパターンは、動画・音楽アプリで広く採用されている。",
+      "notchTitle": "上部のインジケーター（ノッチ）",
+      "notchDesc": "全画面シートの上部にある細い横棒（ドラッグハンドル）は、「このUIは引っ張れる」というシグナル。小さくても存在感があり、ユーザーに操作を促す。"
+    }
+  },
+  "quiz3": {
+    "missionText": "この曲最高！ずっとこれだけを繰り返し聴きたいな",
+    "insight": {
+      "title": "繰り返しボタンの意味がわかった？",
+      "subtitle": "3段階リピートの視覚的切り替え",
+      "repeatTitle": "リピートボタンの3状態",
+      "repeatDesc": "🔁（全体リピート）→🔂（1曲リピート）→なし（オフ）の3段階が1つのボタンで切り替わる。「1」の数字バッジが付いて初めて1曲リピートとわかる記号表現だ。",
+      "iconTitle": "循環矢印＋「1」の組み合わせ",
+      "iconDesc": "2本の矢印が循環している記号は「繰り返し」を表すが、「1」が付くと「1曲だけ」の意味に変わる。修飾子（数字）で意味を拡張するUI表現の好例だ。",
+      "tapTitle": "連続タップで状態を巡回",
+      "tapDesc": "同じボタンを繰り返しタップすることで複数の状態を切り替える「サイクル操作」は、音楽プレイヤーに限らず多くのアプリで使われるUXパターンだ。"
+    }
+  },
+  "quiz4": {
+    "missionText": "なんて歌ってるんだろう？歌詞を確認してみて",
+    "insight": {
+      "title": "歌詞エリアをどうやって引き上げた？",
+      "subtitle": "ドラッグシートの「引き上げ」パターン",
+      "dragTitle": "下部シートを上に引き上げる",
+      "dragDesc": "画面下部に少しだけ見えるパネルを上にスワイプして全画面に引き上げる操作は、Googleマップの場所情報シートで広く普及した。「つかんで引き上げる」物理的な感覚がそのままUIに反映されている。",
+      "handleTitle": "ドラッグハンドルが「操作できる」を伝える",
+      "handleDesc": "パネル上部の細い横棒（ドラッグハンドル）は、このUIが上下にドラッグできることを示すシグナル。文字の代わりに形状でインタラクティブ性を伝えるアフォーダンスの典型例だ。",
+      "lyricsTitle": "歌詞表示はスクロールと組み合わせ",
+      "lyricsDesc": "引き上げたシート内で歌詞がスクロールできる構造は、「一度引き上げれば好きなだけ読める」という期待に応える。シートの状態とコンテンツの状態を分離した優れた設計だ。"
+    }
+  },
+  "common": {
+    "appTitle": "MusicHub",
+    "homeTab": "Home",
+    "libraryTab": "Library",
+    "searchTab": "Search",
+    "likeButton": "Like",
+    "moreButton": "More",
+    "playlistTitle": "マイプレイリスト",
+    "songCount": "{count}曲",
+    "@songCount": { "param": "count" },
+    "lyrics": "歌詞",
+    "lyricsNotAvailable": "歌詞はありません",
+    "quitConfirmTitle": "ゲームを中断しますか？",
+    "quitConfirmMessage": "プレイ中のゲームを終了します。",
+    "continueButton": "続ける",
+    "quitButton": "終了する"
+  },
+  "songs": {
+    "song1Title": "Starlight Drive",
+    "song1Artist": "The Cosmic Band",
+    "song1Lyrics": "Driving down the starlit road\nFeeling free, no heavy load\nNeon lights and city dreams\nNothing's ever what it seems\n\nRide with me through the night\nEverything will be alright\nStarlight drive, starlight drive\nKeep us feeling so alive",
+    "song2Title": "Ocean Waves",
+    "song2Artist": "Blue Horizon",
+    "song2Lyrics": "The ocean calls my name tonight\nWaves of blue in morning light\nSalt and sea and endless sky\nWatching seagulls as they fly\n\nLet the tide wash away\nAll the worries of the day\nOcean waves, ocean waves\nFind the peace that silence saves"
+  }
+}

--- a/packages/quizzes/music/assets/i18n/xx.i18n.json
+++ b/packages/quizzes/music/assets/i18n/xx.i18n.json
@@ -66,7 +66,9 @@
     "quitConfirmTitle": "Quit?",
     "quitConfirmMessage": "Game will end.",
     "continueButton": "Continue",
-    "quitButton": "Quit"
+    "quitButton": "Quit",
+    "mockCurrentTime": "1:12",
+    "mockDuration": "3:45"
   },
   "songs": {
     "song1Title": "Starlight Drive",

--- a/packages/quizzes/music/assets/i18n/xx.i18n.json
+++ b/packages/quizzes/music/assets/i18n/xx.i18n.json
@@ -1,0 +1,79 @@
+{
+  "quiz1": {
+    "missionText": "Skip to the next song",
+    "insight": {
+      "title": "Song Navigation",
+      "subtitle": "Swipe or skip",
+      "swipeTitle": "Swipe artwork",
+      "swipeDesc": "Swipe left to skip.",
+      "skipTitle": "Skip button",
+      "skipDesc": "Next track symbol.",
+      "gestureTitle": "Two ways",
+      "gestureDesc": "Swipe or tap works."
+    }
+  },
+  "quiz2": {
+    "missionText": "Minimize the player",
+    "insight": {
+      "title": "Player Control",
+      "subtitle": "Pull down",
+      "dragTitle": "Drag down",
+      "dragDesc": "Pull to minimize.",
+      "miniTitle": "Mini player",
+      "miniDesc": "Music keeps playing.",
+      "notchTitle": "Drag handle",
+      "notchDesc": "Bar shows draggability."
+    }
+  },
+  "quiz3": {
+    "missionText": "Set to 1-song repeat",
+    "insight": {
+      "title": "Repeat Mode",
+      "subtitle": "Tap to cycle",
+      "repeatTitle": "3 states",
+      "repeatDesc": "Tap cycles repeat.",
+      "iconTitle": "Arrow + 1",
+      "iconDesc": "1 badge means one.",
+      "tapTitle": "Cycle tap",
+      "tapDesc": "Same button cycles."
+    }
+  },
+  "quiz4": {
+    "missionText": "Show the lyrics",
+    "insight": {
+      "title": "Lyrics Panel",
+      "subtitle": "Pull up",
+      "dragTitle": "Pull up sheet",
+      "dragDesc": "Swipe up to show.",
+      "handleTitle": "Drag handle",
+      "handleDesc": "Bar is draggable.",
+      "lyricsTitle": "Lyrics scroll",
+      "lyricsDesc": "Scroll inside sheet."
+    }
+  },
+  "common": {
+    "appTitle": "MusicHub",
+    "homeTab": "Home",
+    "libraryTab": "Library",
+    "searchTab": "Search",
+    "likeButton": "Like",
+    "moreButton": "More",
+    "playlistTitle": "Playlist",
+    "songCount": "{count} songs",
+    "@songCount": { "param": "count" },
+    "lyrics": "Lyrics",
+    "lyricsNotAvailable": "No lyrics",
+    "quitConfirmTitle": "Quit?",
+    "quitConfirmMessage": "Game will end.",
+    "continueButton": "Continue",
+    "quitButton": "Quit"
+  },
+  "songs": {
+    "song1Title": "Starlight Drive",
+    "song1Artist": "The Cosmic Band",
+    "song1Lyrics": "Driving down the starlit road\nFeeling free, no heavy load\nNeon lights and city dreams\nNothing's ever what it seems\n\nRide with me through the night\nEverything will be alright",
+    "song2Title": "Ocean Waves",
+    "song2Artist": "Blue Horizon",
+    "song2Lyrics": "The ocean calls my name tonight\nWaves of blue in morning light\nSalt and sea and endless sky\nWatching seagulls as they fly\n\nLet the tide wash away\nAll the worries of the day"
+  }
+}

--- a/packages/quizzes/music/build.yaml
+++ b/packages/quizzes/music/build.yaml
@@ -1,0 +1,9 @@
+targets:
+  $default:
+    sources:
+      include:
+        - assets/i18n/**
+        - lib/gen/**
+        - $package$
+      exclude:
+        - lib/gen/**/*.g.dart

--- a/packages/quizzes/music/lib/i18n/strings.g.dart
+++ b/packages/quizzes/music/lib/i18n/strings.g.dart
@@ -1,0 +1,181 @@
+/// Generated file. Do not edit.
+///
+/// Source: assets/i18n
+/// To regenerate, run: `dart run slang`
+///
+/// Locales: 3
+/// Strings: 168 (56 per locale)
+///
+/// Built on 2026-05-07 at 02:12 UTC
+
+// coverage:ignore-file
+// ignore_for_file: type=lint, unused_import
+// dart format off
+
+import 'package:flutter/widgets.dart';
+import 'package:intl/intl.dart';
+import 'package:slang/generated.dart';
+import 'package:slang_flutter/slang_flutter.dart';
+export 'package:slang_flutter/slang_flutter.dart';
+
+import 'strings_en.g.dart' as l_en;
+import 'strings_xx.g.dart' as l_xx;
+part 'strings_ja.g.dart';
+
+/// Supported locales.
+///
+/// Usage:
+/// - LocaleSettings.setLocale(AppLocale.ja) // set locale
+/// - Locale locale = AppLocale.ja.flutterLocale // get flutter locale from enum
+/// - if (LocaleSettings.currentLocale == AppLocale.ja) // locale check
+enum AppLocale with BaseAppLocale<AppLocale, Translations> {
+	ja(languageCode: 'ja'),
+	en(languageCode: 'en'),
+	xx(languageCode: 'xx');
+
+	const AppLocale({
+		required this.languageCode,
+		this.scriptCode, // ignore: unused_element, unused_element_parameter
+		this.countryCode, // ignore: unused_element, unused_element_parameter
+	});
+
+	@override final String languageCode;
+	@override final String? scriptCode;
+	@override final String? countryCode;
+
+	@override
+	Future<Translations> build({
+		Map<String, Node>? overrides,
+		PluralResolver? cardinalResolver,
+		PluralResolver? ordinalResolver,
+	}) async {
+		return buildSync(
+			overrides: overrides,
+			cardinalResolver: cardinalResolver,
+			ordinalResolver: ordinalResolver,
+		);
+	}
+
+	@override
+	Translations buildSync({
+		Map<String, Node>? overrides,
+		PluralResolver? cardinalResolver,
+		PluralResolver? ordinalResolver,
+	}) {
+		switch (this) {
+			case AppLocale.ja:
+				return TranslationsJa(
+					overrides: overrides,
+					cardinalResolver: cardinalResolver,
+					ordinalResolver: ordinalResolver,
+				);
+			case AppLocale.en:
+				return l_en.TranslationsEn(
+					overrides: overrides,
+					cardinalResolver: cardinalResolver,
+					ordinalResolver: ordinalResolver,
+				);
+			case AppLocale.xx:
+				return l_xx.TranslationsXx(
+					overrides: overrides,
+					cardinalResolver: cardinalResolver,
+					ordinalResolver: ordinalResolver,
+				);
+		}
+	}
+
+	/// Gets current instance managed by [LocaleSettings].
+	Translations get translations => LocaleSettings.instance.getTranslations(this);
+}
+
+/// Method A: Simple
+///
+/// No rebuild after locale change.
+/// Translation happens during initialization of the widget (call of t).
+/// Configurable via 'translate_var'.
+///
+/// Usage:
+/// String a = t.someKey.anotherKey;
+/// String b = t['someKey.anotherKey']; // Only for edge cases!
+Translations get t => LocaleSettings.instance.currentTranslations;
+
+/// Method B: Advanced
+///
+/// All widgets using this method will trigger a rebuild when locale changes.
+/// Use this if you have e.g. a settings page where the user can select the locale during runtime.
+///
+/// Step 1:
+/// wrap your App with
+/// TranslationProvider(
+/// 	child: MyApp()
+/// );
+///
+/// Step 2:
+/// final t = Translations.of(context); // Get t variable.
+/// String a = t.someKey.anotherKey; // Use t variable.
+/// String b = t['someKey.anotherKey']; // Only for edge cases!
+class TranslationProvider extends BaseTranslationProvider<AppLocale, Translations> {
+	TranslationProvider({required super.child}) : super(settings: LocaleSettings.instance);
+
+	static InheritedLocaleData<AppLocale, Translations> of(BuildContext context) => InheritedLocaleData.of<AppLocale, Translations>(context);
+}
+
+/// Method B shorthand via [BuildContext] extension method.
+/// Configurable via 'translate_var'.
+///
+/// Usage (e.g. in a widget's build method):
+/// context.t.someKey.anotherKey
+extension BuildContextTranslationsExtension on BuildContext {
+	Translations get t => TranslationProvider.of(this).translations;
+}
+
+/// Manages all translation instances and the current locale
+class LocaleSettings extends BaseFlutterLocaleSettings<AppLocale, Translations> {
+	LocaleSettings._() : super(
+		utils: AppLocaleUtils.instance,
+		lazy: false,
+	);
+
+	static final instance = LocaleSettings._();
+
+	// static aliases (checkout base methods for documentation)
+	static AppLocale get currentLocale => instance.currentLocale;
+	static Stream<AppLocale> getLocaleStream() => instance.getLocaleStream();
+	static Future<AppLocale> setLocale(AppLocale locale, {bool? listenToDeviceLocale = false}) => instance.setLocale(locale, listenToDeviceLocale: listenToDeviceLocale);
+	static Future<AppLocale> setLocaleRaw(String rawLocale, {bool? listenToDeviceLocale = false}) => instance.setLocaleRaw(rawLocale, listenToDeviceLocale: listenToDeviceLocale);
+	static Future<AppLocale> useDeviceLocale() => instance.useDeviceLocale();
+	static Future<void> setPluralResolver({String? language, AppLocale? locale, PluralResolver? cardinalResolver, PluralResolver? ordinalResolver}) => instance.setPluralResolver(
+		language: language,
+		locale: locale,
+		cardinalResolver: cardinalResolver,
+		ordinalResolver: ordinalResolver,
+	);
+
+	// synchronous versions
+	static AppLocale setLocaleSync(AppLocale locale, {bool? listenToDeviceLocale = false}) => instance.setLocaleSync(locale, listenToDeviceLocale: listenToDeviceLocale);
+	static AppLocale setLocaleRawSync(String rawLocale, {bool? listenToDeviceLocale = false}) => instance.setLocaleRawSync(rawLocale, listenToDeviceLocale: listenToDeviceLocale);
+	static AppLocale useDeviceLocaleSync() => instance.useDeviceLocaleSync();
+	static void setPluralResolverSync({String? language, AppLocale? locale, PluralResolver? cardinalResolver, PluralResolver? ordinalResolver}) => instance.setPluralResolverSync(
+		language: language,
+		locale: locale,
+		cardinalResolver: cardinalResolver,
+		ordinalResolver: ordinalResolver,
+	);
+}
+
+/// Provides utility functions without any side effects.
+class AppLocaleUtils extends BaseAppLocaleUtils<AppLocale, Translations> {
+	AppLocaleUtils._() : super(
+		baseLocale: AppLocale.ja,
+		locales: AppLocale.values,
+	);
+
+	static final instance = AppLocaleUtils._();
+
+	// static aliases (checkout base methods for documentation)
+	static AppLocale parse(String rawLocale) => instance.parse(rawLocale);
+	static AppLocale parseLocaleParts({required String languageCode, String? scriptCode, String? countryCode}) => instance.parseLocaleParts(languageCode: languageCode, scriptCode: scriptCode, countryCode: countryCode);
+	static AppLocale findDeviceLocale() => instance.findDeviceLocale();
+	static List<Locale> get supportedLocales => instance.supportedLocales;
+	static List<String> get supportedLocalesRaw => instance.supportedLocalesRaw;
+}

--- a/packages/quizzes/music/lib/i18n/strings.g.dart
+++ b/packages/quizzes/music/lib/i18n/strings.g.dart
@@ -4,9 +4,9 @@
 /// To regenerate, run: `dart run slang`
 ///
 /// Locales: 3
-/// Strings: 168 (56 per locale)
+/// Strings: 174 (58 per locale)
 ///
-/// Built on 2026-05-07 at 02:12 UTC
+/// Built on 2026-05-07 at 05:31 UTC
 
 // coverage:ignore-file
 // ignore_for_file: type=lint, unused_import

--- a/packages/quizzes/music/lib/i18n/strings_en.g.dart
+++ b/packages/quizzes/music/lib/i18n/strings_en.g.dart
@@ -112,6 +112,8 @@ class _TranslationsCommonEn extends TranslationsCommonJa {
 	@override String get quitConfirmMessage => 'Your current game will end.';
 	@override String get continueButton => 'Continue';
 	@override String get quitButton => 'Quit';
+	@override String get mockCurrentTime => '1:12';
+	@override String get mockDuration => '3:45';
 }
 
 // Path: songs
@@ -255,6 +257,8 @@ extension on TranslationsEn {
 			'common.quitConfirmMessage' => 'Your current game will end.',
 			'common.continueButton' => 'Continue',
 			'common.quitButton' => 'Quit',
+			'common.mockCurrentTime' => '1:12',
+			'common.mockDuration' => '3:45',
 			'songs.song1Title' => 'Starlight Drive',
 			'songs.song1Artist' => 'The Cosmic Band',
 			'songs.song1Lyrics' => 'Driving down the starlit road\nFeeling free, no heavy load\nNeon lights and city dreams\nNothing\'s ever what it seems\n\nRide with me through the night\nEverything will be alright\nStarlight drive, starlight drive\nKeep us feeling so alive',

--- a/packages/quizzes/music/lib/i18n/strings_en.g.dart
+++ b/packages/quizzes/music/lib/i18n/strings_en.g.dart
@@ -1,0 +1,267 @@
+///
+/// Generated file. Do not edit.
+///
+// coverage:ignore-file
+// ignore_for_file: type=lint, unused_import
+// dart format off
+
+import 'package:flutter/widgets.dart';
+import 'package:intl/intl.dart';
+import 'package:slang/generated.dart';
+import 'strings.g.dart';
+
+// Path: <root>
+class TranslationsEn extends Translations with BaseTranslations<AppLocale, Translations> {
+	/// You can call this constructor and build your own translation instance of this locale.
+	/// Constructing via the enum [AppLocale.build] is preferred.
+	TranslationsEn({Map<String, Node>? overrides, PluralResolver? cardinalResolver, PluralResolver? ordinalResolver, TranslationMetadata<AppLocale, Translations>? meta})
+		: assert(overrides == null, 'Set "translation_overrides: true" in order to enable this feature.'),
+		  $meta = meta ?? TranslationMetadata(
+		    locale: AppLocale.en,
+		    overrides: overrides ?? {},
+		    cardinalResolver: cardinalResolver,
+		    ordinalResolver: ordinalResolver,
+		  ),
+		  super(cardinalResolver: cardinalResolver, ordinalResolver: ordinalResolver) {
+		super.$meta.setFlatMapFunction($meta.getTranslation); // copy base translations to super.$meta
+		$meta.setFlatMapFunction(_flatMapFunction);
+	}
+
+	/// Metadata for the translations of <en>.
+	@override final TranslationMetadata<AppLocale, Translations> $meta;
+
+	/// Access flat map
+	@override dynamic operator[](String key) => $meta.getTranslation(key) ?? super.$meta.getTranslation(key);
+
+	late final TranslationsEn _root = this; // ignore: unused_field
+
+	@override 
+	TranslationsEn $copyWith({TranslationMetadata<AppLocale, Translations>? meta}) => TranslationsEn(meta: meta ?? this.$meta);
+
+	// Translations
+	@override late final _TranslationsQuiz1En quiz1 = _TranslationsQuiz1En._(_root);
+	@override late final _TranslationsQuiz2En quiz2 = _TranslationsQuiz2En._(_root);
+	@override late final _TranslationsQuiz3En quiz3 = _TranslationsQuiz3En._(_root);
+	@override late final _TranslationsQuiz4En quiz4 = _TranslationsQuiz4En._(_root);
+	@override late final _TranslationsCommonEn common = _TranslationsCommonEn._(_root);
+	@override late final _TranslationsSongsEn songs = _TranslationsSongsEn._(_root);
+}
+
+// Path: quiz1
+class _TranslationsQuiz1En extends TranslationsQuiz1Ja {
+	_TranslationsQuiz1En._(TranslationsEn root) : this._root = root, super.internal(root);
+
+	final TranslationsEn _root; // ignore: unused_field
+
+	// Translations
+	@override String get missionText => 'Don\'t like this song? Try skipping to the next one';
+	@override late final _TranslationsQuiz1InsightEn insight = _TranslationsQuiz1InsightEn._(_root);
+}
+
+// Path: quiz2
+class _TranslationsQuiz2En extends TranslationsQuiz2Ja {
+	_TranslationsQuiz2En._(TranslationsEn root) : this._root = root, super.internal(root);
+
+	final TranslationsEn _root; // ignore: unused_field
+
+	// Translations
+	@override String get missionText => 'Want to browse for a song? Minimize the player to go back';
+	@override late final _TranslationsQuiz2InsightEn insight = _TranslationsQuiz2InsightEn._(_root);
+}
+
+// Path: quiz3
+class _TranslationsQuiz3En extends TranslationsQuiz3Ja {
+	_TranslationsQuiz3En._(TranslationsEn root) : this._root = root, super.internal(root);
+
+	final TranslationsEn _root; // ignore: unused_field
+
+	// Translations
+	@override String get missionText => 'This song is amazing! Set it to repeat just this one song';
+	@override late final _TranslationsQuiz3InsightEn insight = _TranslationsQuiz3InsightEn._(_root);
+}
+
+// Path: quiz4
+class _TranslationsQuiz4En extends TranslationsQuiz4Ja {
+	_TranslationsQuiz4En._(TranslationsEn root) : this._root = root, super.internal(root);
+
+	final TranslationsEn _root; // ignore: unused_field
+
+	// Translations
+	@override String get missionText => 'What are they singing? Try checking the lyrics';
+	@override late final _TranslationsQuiz4InsightEn insight = _TranslationsQuiz4InsightEn._(_root);
+}
+
+// Path: common
+class _TranslationsCommonEn extends TranslationsCommonJa {
+	_TranslationsCommonEn._(TranslationsEn root) : this._root = root, super.internal(root);
+
+	final TranslationsEn _root; // ignore: unused_field
+
+	// Translations
+	@override String get appTitle => 'MusicHub';
+	@override String get homeTab => 'Home';
+	@override String get libraryTab => 'Library';
+	@override String get searchTab => 'Search';
+	@override String get likeButton => 'Like';
+	@override String get moreButton => 'More';
+	@override String get playlistTitle => 'My Playlist';
+	@override String get songCount => '{count} songs';
+	@override String get lyrics => 'Lyrics';
+	@override String get lyricsNotAvailable => 'No lyrics available';
+	@override String get quitConfirmTitle => 'Quit Game?';
+	@override String get quitConfirmMessage => 'Your current game will end.';
+	@override String get continueButton => 'Continue';
+	@override String get quitButton => 'Quit';
+}
+
+// Path: songs
+class _TranslationsSongsEn extends TranslationsSongsJa {
+	_TranslationsSongsEn._(TranslationsEn root) : this._root = root, super.internal(root);
+
+	final TranslationsEn _root; // ignore: unused_field
+
+	// Translations
+	@override String get song1Title => 'Starlight Drive';
+	@override String get song1Artist => 'The Cosmic Band';
+	@override String get song1Lyrics => 'Driving down the starlit road\nFeeling free, no heavy load\nNeon lights and city dreams\nNothing\'s ever what it seems\n\nRide with me through the night\nEverything will be alright\nStarlight drive, starlight drive\nKeep us feeling so alive';
+	@override String get song2Title => 'Ocean Waves';
+	@override String get song2Artist => 'Blue Horizon';
+	@override String get song2Lyrics => 'The ocean calls my name tonight\nWaves of blue in morning light\nSalt and sea and endless sky\nWatching seagulls as they fly\n\nLet the tide wash away\nAll the worries of the day\nOcean waves, ocean waves\nFind the peace that silence saves';
+}
+
+// Path: quiz1.insight
+class _TranslationsQuiz1InsightEn extends TranslationsQuiz1InsightJa {
+	_TranslationsQuiz1InsightEn._(TranslationsEn root) : this._root = root, super.internal(root);
+
+	final TranslationsEn _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'How did you skip to the next song?';
+	@override String get subtitle => 'The swipe-to-change feeling';
+	@override String get swipeTitle => 'Left swipe on album art';
+	@override String get swipeDesc => 'Swiping left on album artwork to go to the next song feels just like flipping through gallery photos. The visual card UI intuitively signals that it can be \'swiped\'.';
+	@override String get skipTitle => 'The skip button (⏭) meaning';
+	@override String get skipDesc => 'The \'▶▶|\' symbol from the cassette era means \'skip to next track\'. Its placement next to the play button (on the right) has become a global standard.';
+	@override String get gestureTitle => 'Dual operation: gesture and button';
+	@override String get gestureDesc => 'Offering the same function (song change) through both swipe and tap lets users choose their preferred input method — a \'multiple input paths\' principle of mobile UX.';
+}
+
+// Path: quiz2.insight
+class _TranslationsQuiz2InsightEn extends TranslationsQuiz2InsightJa {
+	_TranslationsQuiz2InsightEn._(TranslationsEn root) : this._root = root, super.internal(root);
+
+	final TranslationsEn _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'How did you know to drag the screen down?';
+	@override String get subtitle => 'The sheet UI \'pull-down\' pattern';
+	@override String get dragTitle => 'Drag down to \'close\'';
+	@override String get dragDesc => 'Dragging down to minimize the full-screen player became popular through Spotify and Apple Music on iOS. \'Pull down = close/store\' is now a shared concept among smartphone users.';
+	@override String get miniTitle => 'Music continues in mini player';
+	@override String get miniDesc => 'Closing the full-screen view doesn\'t stop the music — playback continues in the mini player at the bottom. This \'keep doing other things while listening\' UX pattern is widely used.';
+	@override String get notchTitle => 'The drag indicator (notch)';
+	@override String get notchDesc => 'The thin horizontal bar at the top of the sheet signals \'this UI can be dragged\'. Small but visually significant, it prompts users to try pulling.';
+}
+
+// Path: quiz3.insight
+class _TranslationsQuiz3InsightEn extends TranslationsQuiz3InsightJa {
+	_TranslationsQuiz3InsightEn._(TranslationsEn root) : this._root = root, super.internal(root);
+
+	final TranslationsEn _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'Did you figure out the repeat button?';
+	@override String get subtitle => 'The 3-state repeat button';
+	@override String get repeatTitle => '3 states in one button';
+	@override String get repeatDesc => '🔁 (loop all) → 🔂 (loop one) → off: three states cycle through one button. The \'1\' badge is what distinguishes \'loop one\' from \'loop all\' — a clever symbol extension.';
+	@override String get iconTitle => 'Circular arrows + \'1\'';
+	@override String get iconDesc => 'Two circular arrows mean \'repeat\', but adding \'1\' changes the meaning to \'repeat this one track\'. A great example of using a modifier number to expand meaning.';
+	@override String get tapTitle => 'Tap to cycle through states';
+	@override String get tapDesc => 'Repeatedly tapping the same button to cycle through states — the \'cycle operation\' UX pattern — is used in many apps beyond music players.';
+}
+
+// Path: quiz4.insight
+class _TranslationsQuiz4InsightEn extends TranslationsQuiz4InsightJa {
+	_TranslationsQuiz4InsightEn._(TranslationsEn root) : this._root = root, super.internal(root);
+
+	final TranslationsEn _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'How did you pull up the lyrics panel?';
+	@override String get subtitle => 'The bottom sheet \'pull-up\' pattern';
+	@override String get dragTitle => 'Pull up the bottom sheet';
+	@override String get dragDesc => 'Swiping up a partially visible panel at the bottom of the screen became mainstream through Google Maps\' place info sheet. The physical sensation of \'grab and pull up\' is directly reflected in the UI.';
+	@override String get handleTitle => 'The drag handle says \'I can be dragged\'';
+	@override String get handleDesc => 'The thin bar at the top of the panel signals that this UI can be dragged up and down. It\'s a classic affordance — using shape instead of text to communicate interactivity.';
+	@override String get lyricsTitle => 'Lyrics combined with scrolling';
+	@override String get lyricsDesc => 'Having lyrics scroll inside the pulled-up sheet answers the expectation of \'once pulled up, I can read as much as I want\' — a clean separation of sheet state and content state.';
+}
+
+/// The flat map containing all translations for locale <en>.
+/// Only for edge cases! For simple maps, use the map function of this library.
+///
+/// The Dart AOT compiler has issues with very large switch statements,
+/// so the map is split into smaller functions (512 entries each).
+extension on TranslationsEn {
+	dynamic _flatMapFunction(String path) {
+		return switch (path) {
+			'quiz1.missionText' => 'Don\'t like this song? Try skipping to the next one',
+			'quiz1.insight.title' => 'How did you skip to the next song?',
+			'quiz1.insight.subtitle' => 'The swipe-to-change feeling',
+			'quiz1.insight.swipeTitle' => 'Left swipe on album art',
+			'quiz1.insight.swipeDesc' => 'Swiping left on album artwork to go to the next song feels just like flipping through gallery photos. The visual card UI intuitively signals that it can be \'swiped\'.',
+			'quiz1.insight.skipTitle' => 'The skip button (⏭) meaning',
+			'quiz1.insight.skipDesc' => 'The \'▶▶|\' symbol from the cassette era means \'skip to next track\'. Its placement next to the play button (on the right) has become a global standard.',
+			'quiz1.insight.gestureTitle' => 'Dual operation: gesture and button',
+			'quiz1.insight.gestureDesc' => 'Offering the same function (song change) through both swipe and tap lets users choose their preferred input method — a \'multiple input paths\' principle of mobile UX.',
+			'quiz2.missionText' => 'Want to browse for a song? Minimize the player to go back',
+			'quiz2.insight.title' => 'How did you know to drag the screen down?',
+			'quiz2.insight.subtitle' => 'The sheet UI \'pull-down\' pattern',
+			'quiz2.insight.dragTitle' => 'Drag down to \'close\'',
+			'quiz2.insight.dragDesc' => 'Dragging down to minimize the full-screen player became popular through Spotify and Apple Music on iOS. \'Pull down = close/store\' is now a shared concept among smartphone users.',
+			'quiz2.insight.miniTitle' => 'Music continues in mini player',
+			'quiz2.insight.miniDesc' => 'Closing the full-screen view doesn\'t stop the music — playback continues in the mini player at the bottom. This \'keep doing other things while listening\' UX pattern is widely used.',
+			'quiz2.insight.notchTitle' => 'The drag indicator (notch)',
+			'quiz2.insight.notchDesc' => 'The thin horizontal bar at the top of the sheet signals \'this UI can be dragged\'. Small but visually significant, it prompts users to try pulling.',
+			'quiz3.missionText' => 'This song is amazing! Set it to repeat just this one song',
+			'quiz3.insight.title' => 'Did you figure out the repeat button?',
+			'quiz3.insight.subtitle' => 'The 3-state repeat button',
+			'quiz3.insight.repeatTitle' => '3 states in one button',
+			'quiz3.insight.repeatDesc' => '🔁 (loop all) → 🔂 (loop one) → off: three states cycle through one button. The \'1\' badge is what distinguishes \'loop one\' from \'loop all\' — a clever symbol extension.',
+			'quiz3.insight.iconTitle' => 'Circular arrows + \'1\'',
+			'quiz3.insight.iconDesc' => 'Two circular arrows mean \'repeat\', but adding \'1\' changes the meaning to \'repeat this one track\'. A great example of using a modifier number to expand meaning.',
+			'quiz3.insight.tapTitle' => 'Tap to cycle through states',
+			'quiz3.insight.tapDesc' => 'Repeatedly tapping the same button to cycle through states — the \'cycle operation\' UX pattern — is used in many apps beyond music players.',
+			'quiz4.missionText' => 'What are they singing? Try checking the lyrics',
+			'quiz4.insight.title' => 'How did you pull up the lyrics panel?',
+			'quiz4.insight.subtitle' => 'The bottom sheet \'pull-up\' pattern',
+			'quiz4.insight.dragTitle' => 'Pull up the bottom sheet',
+			'quiz4.insight.dragDesc' => 'Swiping up a partially visible panel at the bottom of the screen became mainstream through Google Maps\' place info sheet. The physical sensation of \'grab and pull up\' is directly reflected in the UI.',
+			'quiz4.insight.handleTitle' => 'The drag handle says \'I can be dragged\'',
+			'quiz4.insight.handleDesc' => 'The thin bar at the top of the panel signals that this UI can be dragged up and down. It\'s a classic affordance — using shape instead of text to communicate interactivity.',
+			'quiz4.insight.lyricsTitle' => 'Lyrics combined with scrolling',
+			'quiz4.insight.lyricsDesc' => 'Having lyrics scroll inside the pulled-up sheet answers the expectation of \'once pulled up, I can read as much as I want\' — a clean separation of sheet state and content state.',
+			'common.appTitle' => 'MusicHub',
+			'common.homeTab' => 'Home',
+			'common.libraryTab' => 'Library',
+			'common.searchTab' => 'Search',
+			'common.likeButton' => 'Like',
+			'common.moreButton' => 'More',
+			'common.playlistTitle' => 'My Playlist',
+			'common.songCount' => '{count} songs',
+			'common.lyrics' => 'Lyrics',
+			'common.lyricsNotAvailable' => 'No lyrics available',
+			'common.quitConfirmTitle' => 'Quit Game?',
+			'common.quitConfirmMessage' => 'Your current game will end.',
+			'common.continueButton' => 'Continue',
+			'common.quitButton' => 'Quit',
+			'songs.song1Title' => 'Starlight Drive',
+			'songs.song1Artist' => 'The Cosmic Band',
+			'songs.song1Lyrics' => 'Driving down the starlit road\nFeeling free, no heavy load\nNeon lights and city dreams\nNothing\'s ever what it seems\n\nRide with me through the night\nEverything will be alright\nStarlight drive, starlight drive\nKeep us feeling so alive',
+			'songs.song2Title' => 'Ocean Waves',
+			'songs.song2Artist' => 'Blue Horizon',
+			'songs.song2Lyrics' => 'The ocean calls my name tonight\nWaves of blue in morning light\nSalt and sea and endless sky\nWatching seagulls as they fly\n\nLet the tide wash away\nAll the worries of the day\nOcean waves, ocean waves\nFind the peace that silence saves',
+			_ => null,
+		};
+	}
+}

--- a/packages/quizzes/music/lib/i18n/strings_ja.g.dart
+++ b/packages/quizzes/music/lib/i18n/strings_ja.g.dart
@@ -153,6 +153,12 @@ class TranslationsCommonJa {
 
 	/// ja: '終了する'
 	String get quitButton => '終了する';
+
+	/// ja: '1:12'
+	String get mockCurrentTime => '1:12';
+
+	/// ja: '3:45'
+	String get mockDuration => '3:45';
 }
 
 // Path: songs
@@ -372,6 +378,8 @@ extension on Translations {
 			'common.quitConfirmMessage' => 'プレイ中のゲームを終了します。',
 			'common.continueButton' => '続ける',
 			'common.quitButton' => '終了する',
+			'common.mockCurrentTime' => '1:12',
+			'common.mockDuration' => '3:45',
 			'songs.song1Title' => 'Starlight Drive',
 			'songs.song1Artist' => 'The Cosmic Band',
 			'songs.song1Lyrics' => 'Driving down the starlit road\nFeeling free, no heavy load\nNeon lights and city dreams\nNothing\'s ever what it seems\n\nRide with me through the night\nEverything will be alright\nStarlight drive, starlight drive\nKeep us feeling so alive',

--- a/packages/quizzes/music/lib/i18n/strings_ja.g.dart
+++ b/packages/quizzes/music/lib/i18n/strings_ja.g.dart
@@ -1,0 +1,384 @@
+///
+/// Generated file. Do not edit.
+///
+// coverage:ignore-file
+// ignore_for_file: type=lint, unused_import
+// dart format off
+
+part of 'strings.g.dart';
+
+// Path: <root>
+typedef TranslationsJa = Translations; // ignore: unused_element
+class Translations with BaseTranslations<AppLocale, Translations> {
+	/// Returns the current translations of the given [context].
+	///
+	/// Usage:
+	/// final t = Translations.of(context);
+	static Translations of(BuildContext context) => InheritedLocaleData.of<AppLocale, Translations>(context).translations;
+
+	/// You can call this constructor and build your own translation instance of this locale.
+	/// Constructing via the enum [AppLocale.build] is preferred.
+	Translations({Map<String, Node>? overrides, PluralResolver? cardinalResolver, PluralResolver? ordinalResolver, TranslationMetadata<AppLocale, Translations>? meta})
+		: assert(overrides == null, 'Set "translation_overrides: true" in order to enable this feature.'),
+		  $meta = meta ?? TranslationMetadata(
+		    locale: AppLocale.ja,
+		    overrides: overrides ?? {},
+		    cardinalResolver: cardinalResolver,
+		    ordinalResolver: ordinalResolver,
+		  ) {
+		$meta.setFlatMapFunction(_flatMapFunction);
+	}
+
+	/// Metadata for the translations of <ja>.
+	@override final TranslationMetadata<AppLocale, Translations> $meta;
+
+	/// Access flat map
+	dynamic operator[](String key) => $meta.getTranslation(key);
+
+	late final Translations _root = this; // ignore: unused_field
+
+	Translations $copyWith({TranslationMetadata<AppLocale, Translations>? meta}) => Translations(meta: meta ?? this.$meta);
+
+	// Translations
+	late final TranslationsQuiz1Ja quiz1 = TranslationsQuiz1Ja.internal(_root);
+	late final TranslationsQuiz2Ja quiz2 = TranslationsQuiz2Ja.internal(_root);
+	late final TranslationsQuiz3Ja quiz3 = TranslationsQuiz3Ja.internal(_root);
+	late final TranslationsQuiz4Ja quiz4 = TranslationsQuiz4Ja.internal(_root);
+	late final TranslationsCommonJa common = TranslationsCommonJa.internal(_root);
+	late final TranslationsSongsJa songs = TranslationsSongsJa.internal(_root);
+}
+
+// Path: quiz1
+class TranslationsQuiz1Ja {
+	TranslationsQuiz1Ja.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// ja: 'この曲じゃないなぁ。次の曲に進めてみよう'
+	String get missionText => 'この曲じゃないなぁ。次の曲に進めてみよう';
+
+	late final TranslationsQuiz1InsightJa insight = TranslationsQuiz1InsightJa.internal(_root);
+}
+
+// Path: quiz2
+class TranslationsQuiz2Ja {
+	TranslationsQuiz2Ja.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// ja: '曲を探しに戻りたい。再生画面を小さくして収納しよう'
+	String get missionText => '曲を探しに戻りたい。再生画面を小さくして収納しよう';
+
+	late final TranslationsQuiz2InsightJa insight = TranslationsQuiz2InsightJa.internal(_root);
+}
+
+// Path: quiz3
+class TranslationsQuiz3Ja {
+	TranslationsQuiz3Ja.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// ja: 'この曲最高！ずっとこれだけを繰り返し聴きたいな'
+	String get missionText => 'この曲最高！ずっとこれだけを繰り返し聴きたいな';
+
+	late final TranslationsQuiz3InsightJa insight = TranslationsQuiz3InsightJa.internal(_root);
+}
+
+// Path: quiz4
+class TranslationsQuiz4Ja {
+	TranslationsQuiz4Ja.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// ja: 'なんて歌ってるんだろう？歌詞を確認してみて'
+	String get missionText => 'なんて歌ってるんだろう？歌詞を確認してみて';
+
+	late final TranslationsQuiz4InsightJa insight = TranslationsQuiz4InsightJa.internal(_root);
+}
+
+// Path: common
+class TranslationsCommonJa {
+	TranslationsCommonJa.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// ja: 'MusicHub'
+	String get appTitle => 'MusicHub';
+
+	/// ja: 'Home'
+	String get homeTab => 'Home';
+
+	/// ja: 'Library'
+	String get libraryTab => 'Library';
+
+	/// ja: 'Search'
+	String get searchTab => 'Search';
+
+	/// ja: 'Like'
+	String get likeButton => 'Like';
+
+	/// ja: 'More'
+	String get moreButton => 'More';
+
+	/// ja: 'マイプレイリスト'
+	String get playlistTitle => 'マイプレイリスト';
+
+	/// ja: '{count}曲'
+	String get songCount => '{count}曲';
+
+	/// ja: '歌詞'
+	String get lyrics => '歌詞';
+
+	/// ja: '歌詞はありません'
+	String get lyricsNotAvailable => '歌詞はありません';
+
+	/// ja: 'ゲームを中断しますか？'
+	String get quitConfirmTitle => 'ゲームを中断しますか？';
+
+	/// ja: 'プレイ中のゲームを終了します。'
+	String get quitConfirmMessage => 'プレイ中のゲームを終了します。';
+
+	/// ja: '続ける'
+	String get continueButton => '続ける';
+
+	/// ja: '終了する'
+	String get quitButton => '終了する';
+}
+
+// Path: songs
+class TranslationsSongsJa {
+	TranslationsSongsJa.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// ja: 'Starlight Drive'
+	String get song1Title => 'Starlight Drive';
+
+	/// ja: 'The Cosmic Band'
+	String get song1Artist => 'The Cosmic Band';
+
+	/// ja: 'Driving down the starlit road Feeling free, no heavy load Neon lights and city dreams Nothing's ever what it seems Ride with me through the night Everything will be alright Starlight drive, starlight drive Keep us feeling so alive'
+	String get song1Lyrics => 'Driving down the starlit road\nFeeling free, no heavy load\nNeon lights and city dreams\nNothing\'s ever what it seems\n\nRide with me through the night\nEverything will be alright\nStarlight drive, starlight drive\nKeep us feeling so alive';
+
+	/// ja: 'Ocean Waves'
+	String get song2Title => 'Ocean Waves';
+
+	/// ja: 'Blue Horizon'
+	String get song2Artist => 'Blue Horizon';
+
+	/// ja: 'The ocean calls my name tonight Waves of blue in morning light Salt and sea and endless sky Watching seagulls as they fly Let the tide wash away All the worries of the day Ocean waves, ocean waves Find the peace that silence saves'
+	String get song2Lyrics => 'The ocean calls my name tonight\nWaves of blue in morning light\nSalt and sea and endless sky\nWatching seagulls as they fly\n\nLet the tide wash away\nAll the worries of the day\nOcean waves, ocean waves\nFind the peace that silence saves';
+}
+
+// Path: quiz1.insight
+class TranslationsQuiz1InsightJa {
+	TranslationsQuiz1InsightJa.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// ja: 'なぜ次の曲に進めたの？'
+	String get title => 'なぜ次の曲に進めたの？';
+
+	/// ja: 'スワイプで曲を変える感覚'
+	String get subtitle => 'スワイプで曲を変える感覚';
+
+	/// ja: 'ジャケ写の左スワイプ'
+	String get swipeTitle => 'ジャケ写の左スワイプ';
+
+	/// ja: 'アルバムアートを左にスワイプすると次の曲に進む操作は、スマホのギャラリー画像送りと同じ感覚。視覚的なカードUIが「送れる」ことを直感的に示している。'
+	String get swipeDesc => 'アルバムアートを左にスワイプすると次の曲に進む操作は、スマホのギャラリー画像送りと同じ感覚。視覚的なカードUIが「送れる」ことを直感的に示している。';
+
+	/// ja: 'スキップボタン（⏭）の意味'
+	String get skipTitle => 'スキップボタン（⏭）の意味';
+
+	/// ja: 'カセットデッキの時代から続く「▶▶|」記号は、次のトラックへのスキップを意味する。音楽プレイヤー共通の配置（再生ボタンの右隣）が世界標準となっている。'
+	String get skipDesc => 'カセットデッキの時代から続く「▶▶|」記号は、次のトラックへのスキップを意味する。音楽プレイヤー共通の配置（再生ボタンの右隣）が世界標準となっている。';
+
+	/// ja: 'ジェスチャーとボタンの二重操作'
+	String get gestureTitle => 'ジェスチャーとボタンの二重操作';
+
+	/// ja: '同じ機能（曲送り）をスワイプとタップの両方で実現することで、ユーザーは好みの操作方法を選べる。これはモバイルUXの「複数の入力経路」の原則だ。'
+	String get gestureDesc => '同じ機能（曲送り）をスワイプとタップの両方で実現することで、ユーザーは好みの操作方法を選べる。これはモバイルUXの「複数の入力経路」の原則だ。';
+}
+
+// Path: quiz2.insight
+class TranslationsQuiz2InsightJa {
+	TranslationsQuiz2InsightJa.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// ja: 'なぜ画面を下に引けるとわかった？'
+	String get title => 'なぜ画面を下に引けるとわかった？';
+
+	/// ja: 'シートUIの「引き下げ」パターン'
+	String get subtitle => 'シートUIの「引き下げ」パターン';
+
+	/// ja: '下ドラッグで「閉じる」'
+	String get dragTitle => '下ドラッグで「閉じる」';
+
+	/// ja: '全画面から下にドラッグして画面を小さくする操作は、iOSのSpotify・Apple Musicで定着した。「引き下げ = 閉じる/収納」の概念がスマホユーザーの共通認識となっている。'
+	String get dragDesc => '全画面から下にドラッグして画面を小さくする操作は、iOSのSpotify・Apple Musicで定着した。「引き下げ = 閉じる/収納」の概念がスマホユーザーの共通認識となっている。';
+
+	/// ja: 'ミニプレイヤーで音楽を継続'
+	String get miniTitle => 'ミニプレイヤーで音楽を継続';
+
+	/// ja: '全画面を閉じても音楽が止まらず、画面下部のミニプレイヤーで再生が続く。この「ながら操作」のUXパターンは、動画・音楽アプリで広く採用されている。'
+	String get miniDesc => '全画面を閉じても音楽が止まらず、画面下部のミニプレイヤーで再生が続く。この「ながら操作」のUXパターンは、動画・音楽アプリで広く採用されている。';
+
+	/// ja: '上部のインジケーター（ノッチ）'
+	String get notchTitle => '上部のインジケーター（ノッチ）';
+
+	/// ja: '全画面シートの上部にある細い横棒（ドラッグハンドル）は、「このUIは引っ張れる」というシグナル。小さくても存在感があり、ユーザーに操作を促す。'
+	String get notchDesc => '全画面シートの上部にある細い横棒（ドラッグハンドル）は、「このUIは引っ張れる」というシグナル。小さくても存在感があり、ユーザーに操作を促す。';
+}
+
+// Path: quiz3.insight
+class TranslationsQuiz3InsightJa {
+	TranslationsQuiz3InsightJa.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// ja: '繰り返しボタンの意味がわかった？'
+	String get title => '繰り返しボタンの意味がわかった？';
+
+	/// ja: '3段階リピートの視覚的切り替え'
+	String get subtitle => '3段階リピートの視覚的切り替え';
+
+	/// ja: 'リピートボタンの3状態'
+	String get repeatTitle => 'リピートボタンの3状態';
+
+	/// ja: '🔁（全体リピート）→🔂（1曲リピート）→なし（オフ）の3段階が1つのボタンで切り替わる。「1」の数字バッジが付いて初めて1曲リピートとわかる記号表現だ。'
+	String get repeatDesc => '🔁（全体リピート）→🔂（1曲リピート）→なし（オフ）の3段階が1つのボタンで切り替わる。「1」の数字バッジが付いて初めて1曲リピートとわかる記号表現だ。';
+
+	/// ja: '循環矢印＋「1」の組み合わせ'
+	String get iconTitle => '循環矢印＋「1」の組み合わせ';
+
+	/// ja: '2本の矢印が循環している記号は「繰り返し」を表すが、「1」が付くと「1曲だけ」の意味に変わる。修飾子（数字）で意味を拡張するUI表現の好例だ。'
+	String get iconDesc => '2本の矢印が循環している記号は「繰り返し」を表すが、「1」が付くと「1曲だけ」の意味に変わる。修飾子（数字）で意味を拡張するUI表現の好例だ。';
+
+	/// ja: '連続タップで状態を巡回'
+	String get tapTitle => '連続タップで状態を巡回';
+
+	/// ja: '同じボタンを繰り返しタップすることで複数の状態を切り替える「サイクル操作」は、音楽プレイヤーに限らず多くのアプリで使われるUXパターンだ。'
+	String get tapDesc => '同じボタンを繰り返しタップすることで複数の状態を切り替える「サイクル操作」は、音楽プレイヤーに限らず多くのアプリで使われるUXパターンだ。';
+}
+
+// Path: quiz4.insight
+class TranslationsQuiz4InsightJa {
+	TranslationsQuiz4InsightJa.internal(this._root);
+
+	final Translations _root; // ignore: unused_field
+
+	// Translations
+
+	/// ja: '歌詞エリアをどうやって引き上げた？'
+	String get title => '歌詞エリアをどうやって引き上げた？';
+
+	/// ja: 'ドラッグシートの「引き上げ」パターン'
+	String get subtitle => 'ドラッグシートの「引き上げ」パターン';
+
+	/// ja: '下部シートを上に引き上げる'
+	String get dragTitle => '下部シートを上に引き上げる';
+
+	/// ja: '画面下部に少しだけ見えるパネルを上にスワイプして全画面に引き上げる操作は、Googleマップの場所情報シートで広く普及した。「つかんで引き上げる」物理的な感覚がそのままUIに反映されている。'
+	String get dragDesc => '画面下部に少しだけ見えるパネルを上にスワイプして全画面に引き上げる操作は、Googleマップの場所情報シートで広く普及した。「つかんで引き上げる」物理的な感覚がそのままUIに反映されている。';
+
+	/// ja: 'ドラッグハンドルが「操作できる」を伝える'
+	String get handleTitle => 'ドラッグハンドルが「操作できる」を伝える';
+
+	/// ja: 'パネル上部の細い横棒（ドラッグハンドル）は、このUIが上下にドラッグできることを示すシグナル。文字の代わりに形状でインタラクティブ性を伝えるアフォーダンスの典型例だ。'
+	String get handleDesc => 'パネル上部の細い横棒（ドラッグハンドル）は、このUIが上下にドラッグできることを示すシグナル。文字の代わりに形状でインタラクティブ性を伝えるアフォーダンスの典型例だ。';
+
+	/// ja: '歌詞表示はスクロールと組み合わせ'
+	String get lyricsTitle => '歌詞表示はスクロールと組み合わせ';
+
+	/// ja: '引き上げたシート内で歌詞がスクロールできる構造は、「一度引き上げれば好きなだけ読める」という期待に応える。シートの状態とコンテンツの状態を分離した優れた設計だ。'
+	String get lyricsDesc => '引き上げたシート内で歌詞がスクロールできる構造は、「一度引き上げれば好きなだけ読める」という期待に応える。シートの状態とコンテンツの状態を分離した優れた設計だ。';
+}
+
+/// The flat map containing all translations for locale <ja>.
+/// Only for edge cases! For simple maps, use the map function of this library.
+///
+/// The Dart AOT compiler has issues with very large switch statements,
+/// so the map is split into smaller functions (512 entries each).
+extension on Translations {
+	dynamic _flatMapFunction(String path) {
+		return switch (path) {
+			'quiz1.missionText' => 'この曲じゃないなぁ。次の曲に進めてみよう',
+			'quiz1.insight.title' => 'なぜ次の曲に進めたの？',
+			'quiz1.insight.subtitle' => 'スワイプで曲を変える感覚',
+			'quiz1.insight.swipeTitle' => 'ジャケ写の左スワイプ',
+			'quiz1.insight.swipeDesc' => 'アルバムアートを左にスワイプすると次の曲に進む操作は、スマホのギャラリー画像送りと同じ感覚。視覚的なカードUIが「送れる」ことを直感的に示している。',
+			'quiz1.insight.skipTitle' => 'スキップボタン（⏭）の意味',
+			'quiz1.insight.skipDesc' => 'カセットデッキの時代から続く「▶▶|」記号は、次のトラックへのスキップを意味する。音楽プレイヤー共通の配置（再生ボタンの右隣）が世界標準となっている。',
+			'quiz1.insight.gestureTitle' => 'ジェスチャーとボタンの二重操作',
+			'quiz1.insight.gestureDesc' => '同じ機能（曲送り）をスワイプとタップの両方で実現することで、ユーザーは好みの操作方法を選べる。これはモバイルUXの「複数の入力経路」の原則だ。',
+			'quiz2.missionText' => '曲を探しに戻りたい。再生画面を小さくして収納しよう',
+			'quiz2.insight.title' => 'なぜ画面を下に引けるとわかった？',
+			'quiz2.insight.subtitle' => 'シートUIの「引き下げ」パターン',
+			'quiz2.insight.dragTitle' => '下ドラッグで「閉じる」',
+			'quiz2.insight.dragDesc' => '全画面から下にドラッグして画面を小さくする操作は、iOSのSpotify・Apple Musicで定着した。「引き下げ = 閉じる/収納」の概念がスマホユーザーの共通認識となっている。',
+			'quiz2.insight.miniTitle' => 'ミニプレイヤーで音楽を継続',
+			'quiz2.insight.miniDesc' => '全画面を閉じても音楽が止まらず、画面下部のミニプレイヤーで再生が続く。この「ながら操作」のUXパターンは、動画・音楽アプリで広く採用されている。',
+			'quiz2.insight.notchTitle' => '上部のインジケーター（ノッチ）',
+			'quiz2.insight.notchDesc' => '全画面シートの上部にある細い横棒（ドラッグハンドル）は、「このUIは引っ張れる」というシグナル。小さくても存在感があり、ユーザーに操作を促す。',
+			'quiz3.missionText' => 'この曲最高！ずっとこれだけを繰り返し聴きたいな',
+			'quiz3.insight.title' => '繰り返しボタンの意味がわかった？',
+			'quiz3.insight.subtitle' => '3段階リピートの視覚的切り替え',
+			'quiz3.insight.repeatTitle' => 'リピートボタンの3状態',
+			'quiz3.insight.repeatDesc' => '🔁（全体リピート）→🔂（1曲リピート）→なし（オフ）の3段階が1つのボタンで切り替わる。「1」の数字バッジが付いて初めて1曲リピートとわかる記号表現だ。',
+			'quiz3.insight.iconTitle' => '循環矢印＋「1」の組み合わせ',
+			'quiz3.insight.iconDesc' => '2本の矢印が循環している記号は「繰り返し」を表すが、「1」が付くと「1曲だけ」の意味に変わる。修飾子（数字）で意味を拡張するUI表現の好例だ。',
+			'quiz3.insight.tapTitle' => '連続タップで状態を巡回',
+			'quiz3.insight.tapDesc' => '同じボタンを繰り返しタップすることで複数の状態を切り替える「サイクル操作」は、音楽プレイヤーに限らず多くのアプリで使われるUXパターンだ。',
+			'quiz4.missionText' => 'なんて歌ってるんだろう？歌詞を確認してみて',
+			'quiz4.insight.title' => '歌詞エリアをどうやって引き上げた？',
+			'quiz4.insight.subtitle' => 'ドラッグシートの「引き上げ」パターン',
+			'quiz4.insight.dragTitle' => '下部シートを上に引き上げる',
+			'quiz4.insight.dragDesc' => '画面下部に少しだけ見えるパネルを上にスワイプして全画面に引き上げる操作は、Googleマップの場所情報シートで広く普及した。「つかんで引き上げる」物理的な感覚がそのままUIに反映されている。',
+			'quiz4.insight.handleTitle' => 'ドラッグハンドルが「操作できる」を伝える',
+			'quiz4.insight.handleDesc' => 'パネル上部の細い横棒（ドラッグハンドル）は、このUIが上下にドラッグできることを示すシグナル。文字の代わりに形状でインタラクティブ性を伝えるアフォーダンスの典型例だ。',
+			'quiz4.insight.lyricsTitle' => '歌詞表示はスクロールと組み合わせ',
+			'quiz4.insight.lyricsDesc' => '引き上げたシート内で歌詞がスクロールできる構造は、「一度引き上げれば好きなだけ読める」という期待に応える。シートの状態とコンテンツの状態を分離した優れた設計だ。',
+			'common.appTitle' => 'MusicHub',
+			'common.homeTab' => 'Home',
+			'common.libraryTab' => 'Library',
+			'common.searchTab' => 'Search',
+			'common.likeButton' => 'Like',
+			'common.moreButton' => 'More',
+			'common.playlistTitle' => 'マイプレイリスト',
+			'common.songCount' => '{count}曲',
+			'common.lyrics' => '歌詞',
+			'common.lyricsNotAvailable' => '歌詞はありません',
+			'common.quitConfirmTitle' => 'ゲームを中断しますか？',
+			'common.quitConfirmMessage' => 'プレイ中のゲームを終了します。',
+			'common.continueButton' => '続ける',
+			'common.quitButton' => '終了する',
+			'songs.song1Title' => 'Starlight Drive',
+			'songs.song1Artist' => 'The Cosmic Band',
+			'songs.song1Lyrics' => 'Driving down the starlit road\nFeeling free, no heavy load\nNeon lights and city dreams\nNothing\'s ever what it seems\n\nRide with me through the night\nEverything will be alright\nStarlight drive, starlight drive\nKeep us feeling so alive',
+			'songs.song2Title' => 'Ocean Waves',
+			'songs.song2Artist' => 'Blue Horizon',
+			'songs.song2Lyrics' => 'The ocean calls my name tonight\nWaves of blue in morning light\nSalt and sea and endless sky\nWatching seagulls as they fly\n\nLet the tide wash away\nAll the worries of the day\nOcean waves, ocean waves\nFind the peace that silence saves',
+			_ => null,
+		};
+	}
+}

--- a/packages/quizzes/music/lib/i18n/strings_xx.g.dart
+++ b/packages/quizzes/music/lib/i18n/strings_xx.g.dart
@@ -1,0 +1,267 @@
+///
+/// Generated file. Do not edit.
+///
+// coverage:ignore-file
+// ignore_for_file: type=lint, unused_import
+// dart format off
+
+import 'package:flutter/widgets.dart';
+import 'package:intl/intl.dart';
+import 'package:slang/generated.dart';
+import 'strings.g.dart';
+
+// Path: <root>
+class TranslationsXx extends Translations with BaseTranslations<AppLocale, Translations> {
+	/// You can call this constructor and build your own translation instance of this locale.
+	/// Constructing via the enum [AppLocale.build] is preferred.
+	TranslationsXx({Map<String, Node>? overrides, PluralResolver? cardinalResolver, PluralResolver? ordinalResolver, TranslationMetadata<AppLocale, Translations>? meta})
+		: assert(overrides == null, 'Set "translation_overrides: true" in order to enable this feature.'),
+		  $meta = meta ?? TranslationMetadata(
+		    locale: AppLocale.xx,
+		    overrides: overrides ?? {},
+		    cardinalResolver: cardinalResolver,
+		    ordinalResolver: ordinalResolver,
+		  ),
+		  super(cardinalResolver: cardinalResolver, ordinalResolver: ordinalResolver) {
+		super.$meta.setFlatMapFunction($meta.getTranslation); // copy base translations to super.$meta
+		$meta.setFlatMapFunction(_flatMapFunction);
+	}
+
+	/// Metadata for the translations of <xx>.
+	@override final TranslationMetadata<AppLocale, Translations> $meta;
+
+	/// Access flat map
+	@override dynamic operator[](String key) => $meta.getTranslation(key) ?? super.$meta.getTranslation(key);
+
+	late final TranslationsXx _root = this; // ignore: unused_field
+
+	@override 
+	TranslationsXx $copyWith({TranslationMetadata<AppLocale, Translations>? meta}) => TranslationsXx(meta: meta ?? this.$meta);
+
+	// Translations
+	@override late final _TranslationsQuiz1Xx quiz1 = _TranslationsQuiz1Xx._(_root);
+	@override late final _TranslationsQuiz2Xx quiz2 = _TranslationsQuiz2Xx._(_root);
+	@override late final _TranslationsQuiz3Xx quiz3 = _TranslationsQuiz3Xx._(_root);
+	@override late final _TranslationsQuiz4Xx quiz4 = _TranslationsQuiz4Xx._(_root);
+	@override late final _TranslationsCommonXx common = _TranslationsCommonXx._(_root);
+	@override late final _TranslationsSongsXx songs = _TranslationsSongsXx._(_root);
+}
+
+// Path: quiz1
+class _TranslationsQuiz1Xx extends TranslationsQuiz1Ja {
+	_TranslationsQuiz1Xx._(TranslationsXx root) : this._root = root, super.internal(root);
+
+	final TranslationsXx _root; // ignore: unused_field
+
+	// Translations
+	@override String get missionText => 'Skip to the next song';
+	@override late final _TranslationsQuiz1InsightXx insight = _TranslationsQuiz1InsightXx._(_root);
+}
+
+// Path: quiz2
+class _TranslationsQuiz2Xx extends TranslationsQuiz2Ja {
+	_TranslationsQuiz2Xx._(TranslationsXx root) : this._root = root, super.internal(root);
+
+	final TranslationsXx _root; // ignore: unused_field
+
+	// Translations
+	@override String get missionText => 'Minimize the player';
+	@override late final _TranslationsQuiz2InsightXx insight = _TranslationsQuiz2InsightXx._(_root);
+}
+
+// Path: quiz3
+class _TranslationsQuiz3Xx extends TranslationsQuiz3Ja {
+	_TranslationsQuiz3Xx._(TranslationsXx root) : this._root = root, super.internal(root);
+
+	final TranslationsXx _root; // ignore: unused_field
+
+	// Translations
+	@override String get missionText => 'Set to 1-song repeat';
+	@override late final _TranslationsQuiz3InsightXx insight = _TranslationsQuiz3InsightXx._(_root);
+}
+
+// Path: quiz4
+class _TranslationsQuiz4Xx extends TranslationsQuiz4Ja {
+	_TranslationsQuiz4Xx._(TranslationsXx root) : this._root = root, super.internal(root);
+
+	final TranslationsXx _root; // ignore: unused_field
+
+	// Translations
+	@override String get missionText => 'Show the lyrics';
+	@override late final _TranslationsQuiz4InsightXx insight = _TranslationsQuiz4InsightXx._(_root);
+}
+
+// Path: common
+class _TranslationsCommonXx extends TranslationsCommonJa {
+	_TranslationsCommonXx._(TranslationsXx root) : this._root = root, super.internal(root);
+
+	final TranslationsXx _root; // ignore: unused_field
+
+	// Translations
+	@override String get appTitle => 'MusicHub';
+	@override String get homeTab => 'Home';
+	@override String get libraryTab => 'Library';
+	@override String get searchTab => 'Search';
+	@override String get likeButton => 'Like';
+	@override String get moreButton => 'More';
+	@override String get playlistTitle => 'Playlist';
+	@override String get songCount => '{count} songs';
+	@override String get lyrics => 'Lyrics';
+	@override String get lyricsNotAvailable => 'No lyrics';
+	@override String get quitConfirmTitle => 'Quit?';
+	@override String get quitConfirmMessage => 'Game will end.';
+	@override String get continueButton => 'Continue';
+	@override String get quitButton => 'Quit';
+}
+
+// Path: songs
+class _TranslationsSongsXx extends TranslationsSongsJa {
+	_TranslationsSongsXx._(TranslationsXx root) : this._root = root, super.internal(root);
+
+	final TranslationsXx _root; // ignore: unused_field
+
+	// Translations
+	@override String get song1Title => 'Starlight Drive';
+	@override String get song1Artist => 'The Cosmic Band';
+	@override String get song1Lyrics => 'Driving down the starlit road\nFeeling free, no heavy load\nNeon lights and city dreams\nNothing\'s ever what it seems\n\nRide with me through the night\nEverything will be alright';
+	@override String get song2Title => 'Ocean Waves';
+	@override String get song2Artist => 'Blue Horizon';
+	@override String get song2Lyrics => 'The ocean calls my name tonight\nWaves of blue in morning light\nSalt and sea and endless sky\nWatching seagulls as they fly\n\nLet the tide wash away\nAll the worries of the day';
+}
+
+// Path: quiz1.insight
+class _TranslationsQuiz1InsightXx extends TranslationsQuiz1InsightJa {
+	_TranslationsQuiz1InsightXx._(TranslationsXx root) : this._root = root, super.internal(root);
+
+	final TranslationsXx _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'Song Navigation';
+	@override String get subtitle => 'Swipe or skip';
+	@override String get swipeTitle => 'Swipe artwork';
+	@override String get swipeDesc => 'Swipe left to skip.';
+	@override String get skipTitle => 'Skip button';
+	@override String get skipDesc => 'Next track symbol.';
+	@override String get gestureTitle => 'Two ways';
+	@override String get gestureDesc => 'Swipe or tap works.';
+}
+
+// Path: quiz2.insight
+class _TranslationsQuiz2InsightXx extends TranslationsQuiz2InsightJa {
+	_TranslationsQuiz2InsightXx._(TranslationsXx root) : this._root = root, super.internal(root);
+
+	final TranslationsXx _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'Player Control';
+	@override String get subtitle => 'Pull down';
+	@override String get dragTitle => 'Drag down';
+	@override String get dragDesc => 'Pull to minimize.';
+	@override String get miniTitle => 'Mini player';
+	@override String get miniDesc => 'Music keeps playing.';
+	@override String get notchTitle => 'Drag handle';
+	@override String get notchDesc => 'Bar shows draggability.';
+}
+
+// Path: quiz3.insight
+class _TranslationsQuiz3InsightXx extends TranslationsQuiz3InsightJa {
+	_TranslationsQuiz3InsightXx._(TranslationsXx root) : this._root = root, super.internal(root);
+
+	final TranslationsXx _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'Repeat Mode';
+	@override String get subtitle => 'Tap to cycle';
+	@override String get repeatTitle => '3 states';
+	@override String get repeatDesc => 'Tap cycles repeat.';
+	@override String get iconTitle => 'Arrow + 1';
+	@override String get iconDesc => '1 badge means one.';
+	@override String get tapTitle => 'Cycle tap';
+	@override String get tapDesc => 'Same button cycles.';
+}
+
+// Path: quiz4.insight
+class _TranslationsQuiz4InsightXx extends TranslationsQuiz4InsightJa {
+	_TranslationsQuiz4InsightXx._(TranslationsXx root) : this._root = root, super.internal(root);
+
+	final TranslationsXx _root; // ignore: unused_field
+
+	// Translations
+	@override String get title => 'Lyrics Panel';
+	@override String get subtitle => 'Pull up';
+	@override String get dragTitle => 'Pull up sheet';
+	@override String get dragDesc => 'Swipe up to show.';
+	@override String get handleTitle => 'Drag handle';
+	@override String get handleDesc => 'Bar is draggable.';
+	@override String get lyricsTitle => 'Lyrics scroll';
+	@override String get lyricsDesc => 'Scroll inside sheet.';
+}
+
+/// The flat map containing all translations for locale <xx>.
+/// Only for edge cases! For simple maps, use the map function of this library.
+///
+/// The Dart AOT compiler has issues with very large switch statements,
+/// so the map is split into smaller functions (512 entries each).
+extension on TranslationsXx {
+	dynamic _flatMapFunction(String path) {
+		return switch (path) {
+			'quiz1.missionText' => 'Skip to the next song',
+			'quiz1.insight.title' => 'Song Navigation',
+			'quiz1.insight.subtitle' => 'Swipe or skip',
+			'quiz1.insight.swipeTitle' => 'Swipe artwork',
+			'quiz1.insight.swipeDesc' => 'Swipe left to skip.',
+			'quiz1.insight.skipTitle' => 'Skip button',
+			'quiz1.insight.skipDesc' => 'Next track symbol.',
+			'quiz1.insight.gestureTitle' => 'Two ways',
+			'quiz1.insight.gestureDesc' => 'Swipe or tap works.',
+			'quiz2.missionText' => 'Minimize the player',
+			'quiz2.insight.title' => 'Player Control',
+			'quiz2.insight.subtitle' => 'Pull down',
+			'quiz2.insight.dragTitle' => 'Drag down',
+			'quiz2.insight.dragDesc' => 'Pull to minimize.',
+			'quiz2.insight.miniTitle' => 'Mini player',
+			'quiz2.insight.miniDesc' => 'Music keeps playing.',
+			'quiz2.insight.notchTitle' => 'Drag handle',
+			'quiz2.insight.notchDesc' => 'Bar shows draggability.',
+			'quiz3.missionText' => 'Set to 1-song repeat',
+			'quiz3.insight.title' => 'Repeat Mode',
+			'quiz3.insight.subtitle' => 'Tap to cycle',
+			'quiz3.insight.repeatTitle' => '3 states',
+			'quiz3.insight.repeatDesc' => 'Tap cycles repeat.',
+			'quiz3.insight.iconTitle' => 'Arrow + 1',
+			'quiz3.insight.iconDesc' => '1 badge means one.',
+			'quiz3.insight.tapTitle' => 'Cycle tap',
+			'quiz3.insight.tapDesc' => 'Same button cycles.',
+			'quiz4.missionText' => 'Show the lyrics',
+			'quiz4.insight.title' => 'Lyrics Panel',
+			'quiz4.insight.subtitle' => 'Pull up',
+			'quiz4.insight.dragTitle' => 'Pull up sheet',
+			'quiz4.insight.dragDesc' => 'Swipe up to show.',
+			'quiz4.insight.handleTitle' => 'Drag handle',
+			'quiz4.insight.handleDesc' => 'Bar is draggable.',
+			'quiz4.insight.lyricsTitle' => 'Lyrics scroll',
+			'quiz4.insight.lyricsDesc' => 'Scroll inside sheet.',
+			'common.appTitle' => 'MusicHub',
+			'common.homeTab' => 'Home',
+			'common.libraryTab' => 'Library',
+			'common.searchTab' => 'Search',
+			'common.likeButton' => 'Like',
+			'common.moreButton' => 'More',
+			'common.playlistTitle' => 'Playlist',
+			'common.songCount' => '{count} songs',
+			'common.lyrics' => 'Lyrics',
+			'common.lyricsNotAvailable' => 'No lyrics',
+			'common.quitConfirmTitle' => 'Quit?',
+			'common.quitConfirmMessage' => 'Game will end.',
+			'common.continueButton' => 'Continue',
+			'common.quitButton' => 'Quit',
+			'songs.song1Title' => 'Starlight Drive',
+			'songs.song1Artist' => 'The Cosmic Band',
+			'songs.song1Lyrics' => 'Driving down the starlit road\nFeeling free, no heavy load\nNeon lights and city dreams\nNothing\'s ever what it seems\n\nRide with me through the night\nEverything will be alright',
+			'songs.song2Title' => 'Ocean Waves',
+			'songs.song2Artist' => 'Blue Horizon',
+			'songs.song2Lyrics' => 'The ocean calls my name tonight\nWaves of blue in morning light\nSalt and sea and endless sky\nWatching seagulls as they fly\n\nLet the tide wash away\nAll the worries of the day',
+			_ => null,
+		};
+	}
+}

--- a/packages/quizzes/music/lib/i18n/strings_xx.g.dart
+++ b/packages/quizzes/music/lib/i18n/strings_xx.g.dart
@@ -112,6 +112,8 @@ class _TranslationsCommonXx extends TranslationsCommonJa {
 	@override String get quitConfirmMessage => 'Game will end.';
 	@override String get continueButton => 'Continue';
 	@override String get quitButton => 'Quit';
+	@override String get mockCurrentTime => '1:12';
+	@override String get mockDuration => '3:45';
 }
 
 // Path: songs
@@ -255,6 +257,8 @@ extension on TranslationsXx {
 			'common.quitConfirmMessage' => 'Game will end.',
 			'common.continueButton' => 'Continue',
 			'common.quitButton' => 'Quit',
+			'common.mockCurrentTime' => '1:12',
+			'common.mockDuration' => '3:45',
 			'songs.song1Title' => 'Starlight Drive',
 			'songs.song1Artist' => 'The Cosmic Band',
 			'songs.song1Lyrics' => 'Driving down the starlit road\nFeeling free, no heavy load\nNeon lights and city dreams\nNothing\'s ever what it seems\n\nRide with me through the night\nEverything will be alright',

--- a/packages/quizzes/music/lib/music.dart
+++ b/packages/quizzes/music/lib/music.dart
@@ -1,0 +1,5 @@
+export 'i18n/strings.g.dart';
+export 'src/presentation/quiz1_next_song/next_song_quiz_screen.dart';
+export 'src/presentation/quiz2_minimize_player/minimize_player_quiz_screen.dart';
+export 'src/presentation/quiz3_one_repeat/one_repeat_quiz_screen.dart';
+export 'src/presentation/quiz4_lyrics/lyrics_quiz_screen.dart';

--- a/packages/quizzes/music/lib/src/application/quiz_lyrics_use_case.dart
+++ b/packages/quizzes/music/lib/src/application/quiz_lyrics_use_case.dart
@@ -1,0 +1,5 @@
+class QuizLyricsUseCase {
+  const QuizLyricsUseCase();
+
+  bool isClear({required double lyricsSheetSize}) => lyricsSheetSize >= 0.5;
+}

--- a/packages/quizzes/music/lib/src/application/quiz_minimize_player_use_case.dart
+++ b/packages/quizzes/music/lib/src/application/quiz_minimize_player_use_case.dart
@@ -1,0 +1,5 @@
+class QuizMinimizePlayerUseCase {
+  const QuizMinimizePlayerUseCase();
+
+  bool isClear({required bool isExpanded}) => !isExpanded;
+}

--- a/packages/quizzes/music/lib/src/application/quiz_next_song_use_case.dart
+++ b/packages/quizzes/music/lib/src/application/quiz_next_song_use_case.dart
@@ -1,0 +1,9 @@
+class QuizNextSongUseCase {
+  const QuizNextSongUseCase();
+
+  bool isClear({
+    required int previousIndex,
+    required int currentIndex,
+  }) =>
+      currentIndex != previousIndex;
+}

--- a/packages/quizzes/music/lib/src/application/quiz_one_repeat_use_case.dart
+++ b/packages/quizzes/music/lib/src/application/quiz_one_repeat_use_case.dart
@@ -1,0 +1,7 @@
+import 'package:just_audio/just_audio.dart';
+
+class QuizOneRepeatUseCase {
+  const QuizOneRepeatUseCase();
+
+  bool isClear({required LoopMode repeatMode}) => repeatMode == LoopMode.one;
+}

--- a/packages/quizzes/music/lib/src/domain/entities/music_song.dart
+++ b/packages/quizzes/music/lib/src/domain/entities/music_song.dart
@@ -1,0 +1,63 @@
+class MusicSong {
+  const MusicSong({
+    required this.id,
+    required this.title,
+    required this.artist,
+    required this.albumArtUrl,
+    required this.audioAssetPath,
+    required this.lyrics,
+    this.colorSeed = 0,
+  });
+
+  final String id;
+  final String title;
+  final String artist;
+  final String albumArtUrl;
+  final String audioAssetPath;
+  final String lyrics;
+  final int colorSeed;
+
+  MusicSong copyWith({
+    String? id,
+    String? title,
+    String? artist,
+    String? albumArtUrl,
+    String? audioAssetPath,
+    String? lyrics,
+    int? colorSeed,
+  }) {
+    return MusicSong(
+      id: id ?? this.id,
+      title: title ?? this.title,
+      artist: artist ?? this.artist,
+      albumArtUrl: albumArtUrl ?? this.albumArtUrl,
+      audioAssetPath: audioAssetPath ?? this.audioAssetPath,
+      lyrics: lyrics ?? this.lyrics,
+      colorSeed: colorSeed ?? this.colorSeed,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is MusicSong &&
+          runtimeType == other.runtimeType &&
+          id == other.id &&
+          title == other.title &&
+          artist == other.artist &&
+          albumArtUrl == other.albumArtUrl &&
+          audioAssetPath == other.audioAssetPath &&
+          lyrics == other.lyrics &&
+          colorSeed == other.colorSeed;
+
+  @override
+  int get hashCode => Object.hash(
+        id,
+        title,
+        artist,
+        albumArtUrl,
+        audioAssetPath,
+        lyrics,
+        colorSeed,
+      );
+}

--- a/packages/quizzes/music/lib/src/domain/music_catalog.dart
+++ b/packages/quizzes/music/lib/src/domain/music_catalog.dart
@@ -10,27 +10,6 @@ abstract final class MusicCatalog {
     'packages/music/assets/audio/song2.mp3',
   ];
 
-  static List<MusicSong> buildSongs($music.Translations t) => [
-        MusicSong(
-          id: 's1',
-          title: t.songs.song1Title,
-          artist: t.songs.song1Artist,
-          albumArtUrl: '',
-          audioAssetPath: audioPaths[0],
-          lyrics: t.songs.song1Lyrics,
-          colorSeed: 0,
-        ),
-        MusicSong(
-          id: 's2',
-          title: t.songs.song2Title,
-          artist: t.songs.song2Artist,
-          albumArtUrl: '',
-          audioAssetPath: audioPaths[1],
-          lyrics: t.songs.song2Lyrics,
-          colorSeed: 1,
-        ),
-      ];
-
   static const List<Color> albumColors = [
     Color(0xFF6A1B9A),
     Color(0xFF0277BD),
@@ -40,4 +19,33 @@ abstract final class MusicCatalog {
     Icons.music_note,
     Icons.waves,
   ];
+
+  static List<MusicSong> buildSongs($music.Translations t) {
+    assert(
+      audioPaths.length == songCount &&
+          albumColors.length == songCount &&
+          albumIcons.length == songCount,
+      'MusicCatalog: all lists must have length $songCount',
+    );
+    return [
+      MusicSong(
+        id: 's1',
+        title: t.songs.song1Title,
+        artist: t.songs.song1Artist,
+        albumArtUrl: '',
+        audioAssetPath: audioPaths[0],
+        lyrics: t.songs.song1Lyrics,
+        colorSeed: 0,
+      ),
+      MusicSong(
+        id: 's2',
+        title: t.songs.song2Title,
+        artist: t.songs.song2Artist,
+        albumArtUrl: '',
+        audioAssetPath: audioPaths[1],
+        lyrics: t.songs.song2Lyrics,
+        colorSeed: 1,
+      ),
+    ];
+  }
 }

--- a/packages/quizzes/music/lib/src/domain/music_catalog.dart
+++ b/packages/quizzes/music/lib/src/domain/music_catalog.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:music/src/domain/entities/music_song.dart';
+
+abstract final class MusicCatalog {
+  static const List<MusicSong> songs = [
+    MusicSong(
+      id: 's1',
+      title: 'Starlight Drive',
+      artist: 'The Cosmic Band',
+      albumArtUrl: '',
+      audioAssetPath: 'packages/music/assets/audio/song1.mp3',
+      lyrics:
+          'Driving down the starlit road\n'
+          'Feeling free, no heavy load\n'
+          'Neon lights and city dreams\n'
+          "Nothing's ever what it seems\n"
+          '\n'
+          'Ride with me through the night\n'
+          'Everything will be alright\n'
+          'Starlight drive, starlight drive\n'
+          'Keep us feeling so alive',
+      colorSeed: 0,
+    ),
+    MusicSong(
+      id: 's2',
+      title: 'Ocean Waves',
+      artist: 'Blue Horizon',
+      albumArtUrl: '',
+      audioAssetPath: 'packages/music/assets/audio/song2.mp3',
+      lyrics:
+          'The ocean calls my name tonight\n'
+          'Waves of blue in morning light\n'
+          'Salt and sea and endless sky\n'
+          'Watching seagulls as they fly\n'
+          '\n'
+          'Let the tide wash away\n'
+          'All the worries of the day\n'
+          'Ocean waves, ocean waves\n'
+          'Find the peace that silence saves',
+      colorSeed: 1,
+    ),
+  ];
+
+  static const List<Color> albumColors = [
+    Color(0xFF6A1B9A),
+    Color(0xFF0277BD),
+  ];
+
+  static const List<IconData> albumIcons = [
+    Icons.music_note,
+    Icons.waves,
+  ];
+}

--- a/packages/quizzes/music/lib/src/domain/music_catalog.dart
+++ b/packages/quizzes/music/lib/src/domain/music_catalog.dart
@@ -1,45 +1,35 @@
 import 'package:flutter/material.dart';
 import 'package:music/src/domain/entities/music_song.dart';
+import '../../i18n/strings.g.dart' as $music;
 
 abstract final class MusicCatalog {
-  static const List<MusicSong> songs = [
-    MusicSong(
-      id: 's1',
-      title: 'Starlight Drive',
-      artist: 'The Cosmic Band',
-      albumArtUrl: '',
-      audioAssetPath: 'packages/music/assets/audio/song1.mp3',
-      lyrics:
-          'Driving down the starlit road\n'
-          'Feeling free, no heavy load\n'
-          'Neon lights and city dreams\n'
-          "Nothing's ever what it seems\n"
-          '\n'
-          'Ride with me through the night\n'
-          'Everything will be alright\n'
-          'Starlight drive, starlight drive\n'
-          'Keep us feeling so alive',
-      colorSeed: 0,
-    ),
-    MusicSong(
-      id: 's2',
-      title: 'Ocean Waves',
-      artist: 'Blue Horizon',
-      albumArtUrl: '',
-      audioAssetPath: 'packages/music/assets/audio/song2.mp3',
-      lyrics:
-          'The ocean calls my name tonight\n'
-          'Waves of blue in morning light\n'
-          'Salt and sea and endless sky\n'
-          'Watching seagulls as they fly\n'
-          '\n'
-          'Let the tide wash away\n'
-          'All the worries of the day\n'
-          'Ocean waves, ocean waves\n'
-          'Find the peace that silence saves',
-      colorSeed: 1,
-    ),
+  static const int songCount = 2;
+
+  static const List<String> audioPaths = [
+    'packages/music/assets/audio/song1.mp3',
+    'packages/music/assets/audio/song2.mp3',
   ];
+
+  static List<MusicSong> buildSongs($music.Translations t) => [
+        MusicSong(
+          id: 's1',
+          title: t.songs.song1Title,
+          artist: t.songs.song1Artist,
+          albumArtUrl: '',
+          audioAssetPath: audioPaths[0],
+          lyrics: t.songs.song1Lyrics,
+          colorSeed: 0,
+        ),
+        MusicSong(
+          id: 's2',
+          title: t.songs.song2Title,
+          artist: t.songs.song2Artist,
+          albumArtUrl: '',
+          audioAssetPath: audioPaths[1],
+          lyrics: t.songs.song2Lyrics,
+          colorSeed: 1,
+        ),
+      ];
 
   static const List<Color> albumColors = [
     Color(0xFF6A1B9A),

--- a/packages/quizzes/music/lib/src/domain/music_quiz_config.dart
+++ b/packages/quizzes/music/lib/src/domain/music_quiz_config.dart
@@ -1,0 +1,6 @@
+abstract final class MusicQuizConfig {
+  static const int quiz1TimeLimitSeconds = 30;
+  static const int quiz2TimeLimitSeconds = 45;
+  static const int quiz3TimeLimitSeconds = 60;
+  static const int quiz4TimeLimitSeconds = 90;
+}

--- a/packages/quizzes/music/lib/src/i18n/music_translations_extension.dart
+++ b/packages/quizzes/music/lib/src/i18n/music_translations_extension.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/widgets.dart';
+import '../../i18n/strings.g.dart' as $music;
+
+/// musicパッケージ専用の翻訳アクセサ拡張。
+///
+/// [s]  : ミッションテキスト・解説など読めるべき日本語テキスト（ja ロケール固定）
+/// [sq] : クイズUI用のカスタム言語テキスト（xx ロケール）
+extension MusicTranslationsExtension on BuildContext {
+  $music.Translations get s => $music.AppLocale.ja.buildSync();
+
+  $music.Translations get sq => $music.AppLocale.xx.buildSync();
+}

--- a/packages/quizzes/music/lib/src/i18n/music_translations_extension.dart
+++ b/packages/quizzes/music/lib/src/i18n/music_translations_extension.dart
@@ -1,12 +1,15 @@
 import 'package:flutter/widgets.dart';
 import '../../i18n/strings.g.dart' as $music;
 
+final _s = $music.AppLocale.ja.buildSync();
+final _sq = $music.AppLocale.xx.buildSync();
+
 /// musicパッケージ専用の翻訳アクセサ拡張。
 ///
 /// [s]  : ミッションテキスト・解説など読めるべき日本語テキスト（ja ロケール固定）
 /// [sq] : クイズUI用のカスタム言語テキスト（xx ロケール）
 extension MusicTranslationsExtension on BuildContext {
-  $music.Translations get s => $music.AppLocale.ja.buildSync();
+  $music.Translations get s => _s;
 
-  $music.Translations get sq => $music.AppLocale.xx.buildSync();
+  $music.Translations get sq => _sq;
 }

--- a/packages/quizzes/music/lib/src/infrastructure/music_quiz_repository.dart
+++ b/packages/quizzes/music/lib/src/infrastructure/music_quiz_repository.dart
@@ -1,0 +1,29 @@
+import 'package:system/system.dart';
+
+class MusicQuizRepository {
+  const MusicQuizRepository(this._quizResultRepository);
+
+  final QuizResultRepository _quizResultRepository;
+
+  Future<void> saveResult({
+    required String quizId,
+    required bool isCleared,
+    int? clearTimeMs,
+    int score = 0,
+    int failureCount = 0,
+  }) async {
+    await _quizResultRepository.logPlay(
+      quizId: quizId,
+      isCleared: isCleared,
+      score: score,
+      failureCount: failureCount,
+    );
+    await _quizResultRepository.saveBestRecord(
+      quizId: quizId,
+      isCleared: isCleared,
+      clearTimeMs: clearTimeMs,
+      score: score,
+      failureCount: failureCount,
+    );
+  }
+}

--- a/packages/quizzes/music/lib/src/infrastructure/music_quiz_repository_provider.dart
+++ b/packages/quizzes/music/lib/src/infrastructure/music_quiz_repository_provider.dart
@@ -1,0 +1,9 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:system/system.dart';
+
+import 'music_quiz_repository.dart';
+
+final musicQuizRepositoryProvider = Provider<MusicQuizRepository>((ref) {
+  final quizResultRepo = ref.watch(quizResultRepositoryProvider);
+  return MusicQuizRepository(quizResultRepo);
+});

--- a/packages/quizzes/music/lib/src/presentation/music_app_scaffold.dart
+++ b/packages/quizzes/music/lib/src/presentation/music_app_scaffold.dart
@@ -1,0 +1,774 @@
+import 'package:flutter/material.dart';
+import 'package:just_audio/just_audio.dart';
+import 'package:quiz_core/quiz_core.dart';
+
+import '../domain/entities/music_song.dart';
+import '../domain/music_catalog.dart';
+import '../i18n/music_translations_extension.dart';
+import 'music_app_state.dart';
+
+class MusicAppScaffold extends StatelessWidget {
+  const MusicAppScaffold({
+    super.key,
+    required this.musicState,
+    required this.songs,
+    required this.quizStatus,
+    required this.remainingSeconds,
+    required this.timeLimitSeconds,
+    required this.missionText,
+    required this.onGiveUp,
+    required this.overlays,
+    required this.onTogglePlayPause,
+    required this.onNextSong,
+    required this.onPreviousSong,
+    required this.onTogglePlayerExpansion,
+    required this.onCycleRepeatMode,
+    required this.onLyricsSizeChanged,
+    this.hintUsed = false,
+    this.onHintTap,
+    this.highlightRepeat = false,
+    this.highlightSwipe = false,
+    this.highlightMinimize = false,
+    this.highlightLyrics = false,
+  });
+
+  final MusicAppState musicState;
+  final List<MusicSong> songs;
+  final QuizStatus quizStatus;
+  final int remainingSeconds;
+  final int timeLimitSeconds;
+  final String missionText;
+  final VoidCallback onGiveUp;
+  final List<Widget> overlays;
+  final VoidCallback onTogglePlayPause;
+  final VoidCallback onNextSong;
+  final VoidCallback onPreviousSong;
+  final ValueChanged<bool> onTogglePlayerExpansion;
+  final VoidCallback onCycleRepeatMode;
+  final ValueChanged<double> onLyricsSizeChanged;
+  final bool hintUsed;
+  final VoidCallback? onHintTap;
+  final bool highlightRepeat;
+  final bool highlightSwipe;
+  final bool highlightMinimize;
+  final bool highlightLyrics;
+
+  @override
+  Widget build(BuildContext context) {
+    final ext = Theme.of(context).extension<MusicAppTheme>()!;
+    final currentSong = songs[musicState.currentSongIndex % songs.length];
+
+    return QuizExitScope(
+      quizStatus: quizStatus,
+      child: Scaffold(
+        backgroundColor: ext.playerBackground,
+        body: Stack(
+          children: [
+            _HomeBackground(ext: ext, songs: songs),
+            if (musicState.isPlayerExpanded)
+              _FullPlayerView(
+                ext: ext,
+                currentSong: currentSong,
+                musicState: musicState,
+                onTogglePlayPause: onTogglePlayPause,
+                onNextSong: onNextSong,
+                onPreviousSong: onPreviousSong,
+                onTogglePlayerExpansion: onTogglePlayerExpansion,
+                onCycleRepeatMode: onCycleRepeatMode,
+                onLyricsSizeChanged: onLyricsSizeChanged,
+                highlightRepeat: highlightRepeat,
+                highlightSwipe: highlightSwipe,
+                highlightMinimize: highlightMinimize,
+                highlightLyrics: highlightLyrics,
+              )
+            else
+              _MiniPlayer(
+                ext: ext,
+                currentSong: currentSong,
+                isPlaying: musicState.isPlaying,
+                onTogglePlayPause: onTogglePlayPause,
+                onExpand: () => onTogglePlayerExpansion(true),
+              ),
+            if (quizStatus == QuizStatus.playing)
+              FloatingMissionBubble(
+                remainingSeconds: remainingSeconds,
+                missionText: missionText,
+                hintUsed: hintUsed,
+                onHintTap: onHintTap,
+                timeLimitSeconds: timeLimitSeconds,
+                onGiveUp: onGiveUp,
+              ),
+            ...overlays,
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// ─── ホーム背景（プレイリスト一覧モック） ─────────────────────────────────────
+
+class _HomeBackground extends StatelessWidget {
+  const _HomeBackground({
+    required this.ext,
+    required this.songs,
+  });
+
+  final MusicAppTheme ext;
+  final List<MusicSong> songs;
+
+  @override
+  Widget build(BuildContext context) {
+    final sq = context.sq;
+    return SafeArea(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+            child: Row(
+              children: [
+                Icon(Icons.music_note, color: ext.brandColor, size: 28),
+                const SizedBox(width: 8),
+                UnreadableText(
+                  sq.common.appTitle,
+                  style: TextStyle(
+                    color: ext.primaryTextColor,
+                    fontSize: 20,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                const Spacer(),
+                Icon(Icons.search, color: ext.primaryTextColor),
+                const SizedBox(width: 12),
+                Icon(Icons.more_vert, color: ext.primaryTextColor),
+              ],
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: UnreadableText(
+              sq.common.playlistTitle,
+              style: TextStyle(
+                color: ext.primaryTextColor,
+                fontSize: 16,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+          Expanded(
+            child: ListView.builder(
+              padding: const EdgeInsets.only(bottom: 80),
+              itemCount: songs.length,
+              itemBuilder: (context, index) {
+                final song = songs[index];
+                final color =
+                    MusicCatalog.albumColors[index % MusicCatalog.albumColors.length];
+                final icon =
+                    MusicCatalog.albumIcons[index % MusicCatalog.albumIcons.length];
+                return ListTile(
+                  leading: Container(
+                    width: 48,
+                    height: 48,
+                    decoration: BoxDecoration(
+                      color: color,
+                      borderRadius: BorderRadius.circular(4),
+                    ),
+                    child: Icon(icon, color: Colors.white, size: 24),
+                  ),
+                  title: UnreadableText(
+                    song.title,
+                    style: TextStyle(
+                      color: ext.primaryTextColor,
+                      fontSize: 14,
+                    ),
+                  ),
+                  subtitle: UnreadableText(
+                    song.artist,
+                    style: TextStyle(color: ext.subTextColor, fontSize: 12),
+                  ),
+                  trailing: Icon(Icons.more_vert, color: ext.subTextColor),
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ─── 全画面プレイヤー ──────────────────────────────────────────────────────────
+
+class _FullPlayerView extends StatelessWidget {
+  const _FullPlayerView({
+    required this.ext,
+    required this.currentSong,
+    required this.musicState,
+    required this.onTogglePlayPause,
+    required this.onNextSong,
+    required this.onPreviousSong,
+    required this.onTogglePlayerExpansion,
+    required this.onCycleRepeatMode,
+    required this.onLyricsSizeChanged,
+    required this.highlightRepeat,
+    required this.highlightSwipe,
+    required this.highlightMinimize,
+    required this.highlightLyrics,
+  });
+
+  final MusicAppTheme ext;
+  final MusicSong currentSong;
+  final MusicAppState musicState;
+  final VoidCallback onTogglePlayPause;
+  final VoidCallback onNextSong;
+  final VoidCallback onPreviousSong;
+  final ValueChanged<bool> onTogglePlayerExpansion;
+  final VoidCallback onCycleRepeatMode;
+  final ValueChanged<double> onLyricsSizeChanged;
+  final bool highlightRepeat;
+  final bool highlightSwipe;
+  final bool highlightMinimize;
+  final bool highlightLyrics;
+
+  @override
+  Widget build(BuildContext context) {
+    final albumColor = MusicCatalog
+        .albumColors[currentSong.colorSeed % MusicCatalog.albumColors.length];
+    final albumIcon = MusicCatalog
+        .albumIcons[currentSong.colorSeed % MusicCatalog.albumIcons.length];
+
+    return GestureDetector(
+      onVerticalDragEnd: (details) {
+        if (details.primaryVelocity != null && details.primaryVelocity! > 200) {
+          onTogglePlayerExpansion(false);
+        }
+      },
+      child: Container(
+        color: ext.playerBackground,
+        child: SafeArea(
+          child: Stack(
+            children: [
+              Column(
+                children: [
+                  _PlayerAppBar(
+                    ext: ext,
+                    highlightMinimize: highlightMinimize,
+                    onMinimize: () => onTogglePlayerExpansion(false),
+                  ),
+                  Expanded(
+                    child: Column(
+                      children: [
+                        const SizedBox(height: 16),
+                        _ArtworkArea(
+                          ext: ext,
+                          albumColor: albumColor,
+                          albumIcon: albumIcon,
+                          onNextSong: onNextSong,
+                          onPreviousSong: onPreviousSong,
+                          highlightSwipe: highlightSwipe,
+                        ),
+                        const SizedBox(height: 24),
+                        _SongInfo(
+                          ext: ext,
+                          currentSong: currentSong,
+                        ),
+                        const SizedBox(height: 24),
+                        _PlaybackControls(
+                          ext: ext,
+                          isPlaying: musicState.isPlaying,
+                          repeatMode: musicState.repeatMode,
+                          onTogglePlayPause: onTogglePlayPause,
+                          onNextSong: onNextSong,
+                          onPreviousSong: onPreviousSong,
+                          onCycleRepeatMode: onCycleRepeatMode,
+                          highlightRepeat: highlightRepeat,
+                        ),
+                        const Spacer(),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+              _LyricsPanel(
+                ext: ext,
+                lyrics: currentSong.lyrics,
+                onLyricsSizeChanged: onLyricsSizeChanged,
+                highlightLyrics: highlightLyrics,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ─── AppBar ────────────────────────────────────────────────────────────────────
+
+class _PlayerAppBar extends StatelessWidget {
+  const _PlayerAppBar({
+    required this.ext,
+    required this.highlightMinimize,
+    required this.onMinimize,
+  });
+
+  final MusicAppTheme ext;
+  final bool highlightMinimize;
+  final VoidCallback onMinimize;
+
+  @override
+  Widget build(BuildContext context) {
+    final sq = context.sq;
+    return Container(
+      height: 56,
+      color: ext.appBarBackground,
+      child: Row(
+        children: [
+          Container(
+            margin: const EdgeInsets.all(8),
+            decoration: highlightMinimize
+                ? BoxDecoration(
+                    border: Border.all(
+                      color: ext.highlightBorderColor,
+                      width: 2,
+                    ),
+                    borderRadius: BorderRadius.circular(20),
+                    color: ext.highlightBorderColor.withValues(alpha: 0.1),
+                  )
+                : null,
+            child: IconButton(
+              icon: Icon(
+                Icons.keyboard_arrow_down,
+                color: ext.primaryTextColor,
+              ),
+              onPressed: onMinimize,
+            ),
+          ),
+          Expanded(
+            child: Center(
+              child: UnreadableText(
+                sq.common.appTitle,
+                style: TextStyle(
+                  color: ext.primaryTextColor,
+                  fontSize: 16,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+          ),
+          IconButton(
+            icon: Icon(Icons.more_vert, color: ext.primaryTextColor),
+            onPressed: null,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ─── アートワークエリア ─────────────────────────────────────────────────────────
+
+class _ArtworkArea extends StatelessWidget {
+  const _ArtworkArea({
+    required this.ext,
+    required this.albumColor,
+    required this.albumIcon,
+    required this.onNextSong,
+    required this.onPreviousSong,
+    required this.highlightSwipe,
+  });
+
+  final MusicAppTheme ext;
+  final Color albumColor;
+  final IconData albumIcon;
+  final VoidCallback onNextSong;
+  final VoidCallback onPreviousSong;
+  final bool highlightSwipe;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 32),
+      child: GestureDetector(
+        onHorizontalDragEnd: (details) {
+          if (details.primaryVelocity != null && details.primaryVelocity! < 0) {
+            onNextSong();
+          } else if (details.primaryVelocity != null &&
+              details.primaryVelocity! > 0) {
+            onPreviousSong();
+          }
+        },
+        child: Container(
+          width: double.infinity,
+          height: 240,
+          decoration: BoxDecoration(
+            color: albumColor,
+            borderRadius: BorderRadius.circular(12),
+            border: highlightSwipe
+                ? Border.all(
+                    color: ext.highlightBorderColor,
+                    width: 3,
+                  )
+                : null,
+          ),
+          child: Center(
+            child: Icon(albumIcon, size: 96, color: Colors.white70),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ─── 曲情報 ────────────────────────────────────────────────────────────────────
+
+class _SongInfo extends StatelessWidget {
+  const _SongInfo({
+    required this.ext,
+    required this.currentSong,
+  });
+
+  final MusicAppTheme ext;
+  final MusicSong currentSong;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 32),
+      child: Row(
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                UnreadableText(
+                  currentSong.title,
+                  style: TextStyle(
+                    color: ext.primaryTextColor,
+                    fontSize: 20,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                UnreadableText(
+                  currentSong.artist,
+                  style: TextStyle(
+                    color: ext.subTextColor,
+                    fontSize: 14,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Icon(Icons.favorite_border, color: ext.subTextColor),
+        ],
+      ),
+    );
+  }
+}
+
+// ─── 再生コントロール ──────────────────────────────────────────────────────────
+
+class _PlaybackControls extends StatelessWidget {
+  const _PlaybackControls({
+    required this.ext,
+    required this.isPlaying,
+    required this.repeatMode,
+    required this.onTogglePlayPause,
+    required this.onNextSong,
+    required this.onPreviousSong,
+    required this.onCycleRepeatMode,
+    required this.highlightRepeat,
+  });
+
+  final MusicAppTheme ext;
+  final bool isPlaying;
+  final LoopMode repeatMode;
+  final VoidCallback onTogglePlayPause;
+  final VoidCallback onNextSong;
+  final VoidCallback onPreviousSong;
+  final VoidCallback onCycleRepeatMode;
+  final bool highlightRepeat;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 24),
+      child: Column(
+        children: [
+          // シークバー（モック）
+          SliderTheme(
+            data: SliderTheme.of(context).copyWith(
+              trackHeight: 3,
+              thumbShape: const RoundSliderThumbShape(enabledThumbRadius: 6),
+              activeTrackColor: ext.activeColor,
+              inactiveTrackColor: ext.inactiveColor,
+              thumbColor: ext.activeColor,
+            ),
+            child: Slider(
+              value: 0.3,
+              onChanged: null,
+            ),
+          ),
+          // 時間表示
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 8),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(
+                  '1:12',
+                  style: TextStyle(color: ext.subTextColor, fontSize: 12),
+                ),
+                Text(
+                  '3:45',
+                  style: TextStyle(color: ext.subTextColor, fontSize: 12),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 8),
+          // コントロールボタン
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: [
+              IconButton(
+                icon: Icon(Icons.shuffle, color: ext.inactiveColor),
+                onPressed: null,
+              ),
+              IconButton(
+                icon: Icon(Icons.skip_previous, color: ext.primaryTextColor, size: 36),
+                onPressed: onPreviousSong,
+              ),
+              GestureDetector(
+                onTap: onTogglePlayPause,
+                child: Container(
+                  width: 64,
+                  height: 64,
+                  decoration: BoxDecoration(
+                    color: ext.activeColor,
+                    shape: BoxShape.circle,
+                  ),
+                  child: Icon(
+                    isPlaying ? Icons.pause : Icons.play_arrow,
+                    color: Colors.white,
+                    size: 36,
+                  ),
+                ),
+              ),
+              IconButton(
+                icon: Icon(Icons.skip_next, color: ext.primaryTextColor, size: 36),
+                onPressed: onNextSong,
+              ),
+              Container(
+                decoration: highlightRepeat
+                    ? BoxDecoration(
+                        border: Border.all(
+                          color: ext.highlightBorderColor,
+                          width: 2,
+                        ),
+                        borderRadius: BorderRadius.circular(20),
+                        color: ext.highlightBorderColor.withValues(alpha: 0.1),
+                      )
+                    : null,
+                child: IconButton(
+                  icon: _buildRepeatIcon(repeatMode, ext),
+                  onPressed: onCycleRepeatMode,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildRepeatIcon(LoopMode mode, MusicAppTheme ext) {
+    return switch (mode) {
+      LoopMode.off => Icon(Icons.repeat, color: ext.inactiveColor),
+      LoopMode.all => Icon(Icons.repeat, color: ext.activeColor),
+      LoopMode.one => Icon(Icons.repeat_one, color: ext.activeColor),
+    };
+  }
+}
+
+// ─── 歌詞パネル ────────────────────────────────────────────────────────────────
+
+class _LyricsPanel extends StatelessWidget {
+  const _LyricsPanel({
+    required this.ext,
+    required this.lyrics,
+    required this.onLyricsSizeChanged,
+    required this.highlightLyrics,
+  });
+
+  final MusicAppTheme ext;
+  final String lyrics;
+  final ValueChanged<double> onLyricsSizeChanged;
+  final bool highlightLyrics;
+
+  @override
+  Widget build(BuildContext context) {
+    final sq = context.sq;
+    return DraggableScrollableSheet(
+      initialChildSize: 0.12,
+      minChildSize: 0.08,
+      maxChildSize: 1.0,
+      builder: (context, scrollController) {
+        return NotificationListener<DraggableScrollableNotification>(
+          onNotification: (notification) {
+            onLyricsSizeChanged(notification.extent);
+            return false;
+          },
+          child: Container(
+            decoration: BoxDecoration(
+              color: ext.cardBackground,
+              borderRadius: const BorderRadius.vertical(top: Radius.circular(16)),
+              border: highlightLyrics
+                  ? Border.all(color: ext.highlightBorderColor, width: 2)
+                  : null,
+            ),
+            child: Column(
+              children: [
+                const SizedBox(height: 8),
+                Container(
+                  width: 40,
+                  height: 4,
+                  decoration: BoxDecoration(
+                    color: ext.inactiveColor,
+                    borderRadius: BorderRadius.circular(2),
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 8),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Icon(Icons.lyrics_outlined, color: ext.subTextColor, size: 16),
+                      const SizedBox(width: 4),
+                      UnreadableText(
+                        sq.common.lyrics,
+                        style: TextStyle(
+                          color: ext.subTextColor,
+                          fontSize: 13,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                Expanded(
+                  child: SingleChildScrollView(
+                    controller: scrollController,
+                    padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 8),
+                    child: lyrics.isEmpty
+                        ? Text(
+                            sq.common.lyricsNotAvailable,
+                            style: TextStyle(
+                              color: ext.subTextColor,
+                              fontSize: 14,
+                            ),
+                            textAlign: TextAlign.center,
+                          )
+                        : Text(
+                            lyrics,
+                            style: TextStyle(
+                              color: ext.primaryTextColor,
+                              fontSize: 16,
+                              height: 1.8,
+                            ),
+                            textAlign: TextAlign.center,
+                          ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+// ─── ミニプレイヤー ────────────────────────────────────────────────────────────
+
+class _MiniPlayer extends StatelessWidget {
+  const _MiniPlayer({
+    required this.ext,
+    required this.currentSong,
+    required this.isPlaying,
+    required this.onTogglePlayPause,
+    required this.onExpand,
+  });
+
+  final MusicAppTheme ext;
+  final MusicSong currentSong;
+  final bool isPlaying;
+  final VoidCallback onTogglePlayPause;
+  final VoidCallback onExpand;
+
+  @override
+  Widget build(BuildContext context) {
+    final albumColor = MusicCatalog
+        .albumColors[currentSong.colorSeed % MusicCatalog.albumColors.length];
+    final albumIcon = MusicCatalog
+        .albumIcons[currentSong.colorSeed % MusicCatalog.albumIcons.length];
+
+    return Positioned(
+      left: 0,
+      right: 0,
+      bottom: 0,
+      child: GestureDetector(
+        onTap: onExpand,
+        child: Container(
+          height: 72,
+          color: ext.miniPlayerBackground,
+          padding: const EdgeInsets.symmetric(horizontal: 12),
+          child: Row(
+            children: [
+              Container(
+                width: 48,
+                height: 48,
+                decoration: BoxDecoration(
+                  color: albumColor,
+                  borderRadius: BorderRadius.circular(4),
+                ),
+                child: Icon(albumIcon, color: Colors.white, size: 24),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    UnreadableText(
+                      currentSong.title,
+                      style: TextStyle(
+                        color: ext.primaryTextColor,
+                        fontSize: 14,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    UnreadableText(
+                      currentSong.artist,
+                      style: TextStyle(color: ext.subTextColor, fontSize: 12),
+                    ),
+                  ],
+                ),
+              ),
+              IconButton(
+                icon: Icon(
+                  isPlaying ? Icons.pause : Icons.play_arrow,
+                  color: ext.primaryTextColor,
+                  size: 28,
+                ),
+                onPressed: onTogglePlayPause,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/quizzes/music/lib/src/presentation/music_app_scaffold.dart
+++ b/packages/quizzes/music/lib/src/presentation/music_app_scaffold.dart
@@ -200,7 +200,7 @@ class _HomeBackground extends StatelessWidget {
 
 // ─── 全画面プレイヤー ──────────────────────────────────────────────────────────
 
-class _FullPlayerView extends StatelessWidget {
+class _FullPlayerView extends StatefulWidget {
   const _FullPlayerView({
     required this.ext,
     required this.currentSong,
@@ -232,71 +232,156 @@ class _FullPlayerView extends StatelessWidget {
   final bool highlightLyrics;
 
   @override
+  State<_FullPlayerView> createState() => _FullPlayerViewState();
+}
+
+class _FullPlayerViewState extends State<_FullPlayerView>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _ctrl;
+  late Animation<double> _anim;
+
+  // 現在の下方向ドラッグ量（0以上）
+  double _dragY = 0;
+  bool _pendingMinimize = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _ctrl = AnimationController(vsync: this)
+      ..addListener(() => setState(() {}))
+      ..addStatusListener(_onAnimStatus);
+    _anim = const AlwaysStoppedAnimation(0.0);
+  }
+
+  @override
+  void dispose() {
+    _ctrl.dispose();
+    super.dispose();
+  }
+
+  void _onAnimStatus(AnimationStatus status) {
+    if (status != AnimationStatus.completed) return;
+    if (_pendingMinimize) {
+      _pendingMinimize = false;
+      widget.onTogglePlayerExpansion(false);
+    } else {
+      setState(() => _dragY = 0);
+    }
+  }
+
+  void _animateTo(double to, {Duration? duration, Curve curve = Curves.easeOutCubic}) {
+    _ctrl.stop();
+    _anim = Tween<double>(begin: _dragY, end: to).animate(
+      CurvedAnimation(parent: _ctrl, curve: curve),
+    );
+    _ctrl.duration = duration ?? const Duration(milliseconds: 300);
+    _ctrl.reset();
+    _ctrl.forward();
+  }
+
+  void _onDragUpdate(DragUpdateDetails details) {
+    if (_ctrl.isAnimating) return;
+    // 下方向のみ反応、上への戻しも許可
+    final newY = (_dragY + details.delta.dy).clamp(0.0, double.infinity);
+    setState(() => _dragY = newY);
+  }
+
+  void _onDragEnd(DragEndDetails details) {
+    if (_ctrl.isAnimating) return;
+    final velocity = details.primaryVelocity ?? 0;
+    final screenHeight = MediaQuery.heightOf(context);
+
+    if (velocity > 400 || _dragY > screenHeight * 0.25) {
+      _pendingMinimize = true;
+      _animateTo(
+        screenHeight,
+        duration: const Duration(milliseconds: 240),
+        curve: Curves.easeInCubic,
+      );
+    } else {
+      _animateTo(
+        0,
+        duration: const Duration(milliseconds: 300),
+        curve: Curves.easeOutCubic,
+      );
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final currentY = _ctrl.isAnimating ? _anim.value : _dragY;
+    final screenHeight = MediaQuery.heightOf(context);
+    final progress = (currentY / screenHeight).clamp(0.0, 1.0);
+    final scale = 1.0 - progress * 0.15;
+
     final albumColor = MusicCatalog
-        .albumColors[currentSong.colorSeed % MusicCatalog.albumColors.length];
+        .albumColors[widget.currentSong.colorSeed % MusicCatalog.albumColors.length];
     final albumIcon = MusicCatalog
-        .albumIcons[currentSong.colorSeed % MusicCatalog.albumIcons.length];
+        .albumIcons[widget.currentSong.colorSeed % MusicCatalog.albumIcons.length];
 
     return GestureDetector(
-      onVerticalDragEnd: (details) {
-        if (details.primaryVelocity != null && details.primaryVelocity! > 200) {
-          onTogglePlayerExpansion(false);
-        }
-      },
-      child: Container(
-        color: ext.playerBackground,
-        child: SafeArea(
-          child: Stack(
-            children: [
-              Column(
+      onVerticalDragUpdate: _onDragUpdate,
+      onVerticalDragEnd: _onDragEnd,
+      child: Transform.translate(
+        offset: Offset(0, currentY),
+        child: Transform.scale(
+          scale: scale,
+          alignment: Alignment.topCenter,
+          child: Container(
+            color: widget.ext.playerBackground,
+            child: SafeArea(
+              child: Stack(
                 children: [
-                  _PlayerAppBar(
-                    ext: ext,
-                    highlightMinimize: highlightMinimize,
-                    onMinimize: () => onTogglePlayerExpansion(false),
+                  Column(
+                    children: [
+                      _PlayerAppBar(
+                        ext: widget.ext,
+                        highlightMinimize: widget.highlightMinimize,
+                        onMinimize: () => widget.onTogglePlayerExpansion(false),
+                      ),
+                      Expanded(
+                        child: Column(
+                          children: [
+                            const SizedBox(height: 16),
+                            _ArtworkArea(
+                              ext: widget.ext,
+                              albumColor: albumColor,
+                              albumIcon: albumIcon,
+                              onNextSong: widget.onNextSong,
+                              onPreviousSong: widget.onPreviousSong,
+                              highlightSwipe: widget.highlightSwipe,
+                            ),
+                            const SizedBox(height: 24),
+                            _SongInfo(
+                              ext: widget.ext,
+                              currentSong: widget.currentSong,
+                            ),
+                            const SizedBox(height: 24),
+                            _PlaybackControls(
+                              ext: widget.ext,
+                              isPlaying: widget.musicState.isPlaying,
+                              repeatMode: widget.musicState.repeatMode,
+                              onTogglePlayPause: widget.onTogglePlayPause,
+                              onNextSong: widget.onNextSong,
+                              onPreviousSong: widget.onPreviousSong,
+                              onCycleRepeatMode: widget.onCycleRepeatMode,
+                              highlightRepeat: widget.highlightRepeat,
+                            ),
+                            const Spacer(),
+                          ],
+                        ),
+                      ),
+                    ],
                   ),
-                  Expanded(
-                    child: Column(
-                      children: [
-                        const SizedBox(height: 16),
-                        _ArtworkArea(
-                          ext: ext,
-                          albumColor: albumColor,
-                          albumIcon: albumIcon,
-                          onNextSong: onNextSong,
-                          onPreviousSong: onPreviousSong,
-                          highlightSwipe: highlightSwipe,
-                        ),
-                        const SizedBox(height: 24),
-                        _SongInfo(
-                          ext: ext,
-                          currentSong: currentSong,
-                        ),
-                        const SizedBox(height: 24),
-                        _PlaybackControls(
-                          ext: ext,
-                          isPlaying: musicState.isPlaying,
-                          repeatMode: musicState.repeatMode,
-                          onTogglePlayPause: onTogglePlayPause,
-                          onNextSong: onNextSong,
-                          onPreviousSong: onPreviousSong,
-                          onCycleRepeatMode: onCycleRepeatMode,
-                          highlightRepeat: highlightRepeat,
-                        ),
-                        const Spacer(),
-                      ],
-                    ),
+                  _LyricsPanel(
+                    ext: widget.ext,
+                    lyrics: widget.currentSong.lyrics,
+                    onLyricsSizeChanged: widget.onLyricsSizeChanged,
+                    highlightLyrics: widget.highlightLyrics,
                   ),
                 ],
               ),
-              _LyricsPanel(
-                ext: ext,
-                lyrics: currentSong.lyrics,
-                onLyricsSizeChanged: onLyricsSizeChanged,
-                highlightLyrics: highlightLyrics,
-              ),
-            ],
+            ),
           ),
         ),
       ),
@@ -367,9 +452,9 @@ class _PlayerAppBar extends StatelessWidget {
   }
 }
 
-// ─── アートワークエリア ─────────────────────────────────────────────────────────
+// ─── アートワークエリア（スワイプアニメーション付き） ─────────────────────────
 
-class _ArtworkArea extends StatelessWidget {
+class _ArtworkArea extends StatefulWidget {
   const _ArtworkArea({
     required this.ext,
     required this.albumColor,
@@ -387,33 +472,143 @@ class _ArtworkArea extends StatelessWidget {
   final bool highlightSwipe;
 
   @override
+  State<_ArtworkArea> createState() => _ArtworkAreaState();
+}
+
+class _ArtworkAreaState extends State<_ArtworkArea>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _ctrl;
+  late Animation<double> _anim;
+
+  // 現在の水平オフセット（ドラッグ中・アニメーション中ともにこの値を参照）
+  double _offset = 0;
+  VoidCallback? _onAnimComplete;
+
+  @override
+  void initState() {
+    super.initState();
+    _ctrl = AnimationController(vsync: this)
+      ..addListener(_onAnimTick)
+      ..addStatusListener(_onAnimStatus);
+    _anim = const AlwaysStoppedAnimation(0.0);
+  }
+
+  @override
+  void dispose() {
+    _ctrl.dispose();
+    super.dispose();
+  }
+
+  void _onAnimTick() {
+    setState(() => _offset = _anim.value);
+  }
+
+  void _onAnimStatus(AnimationStatus status) {
+    if (status != AnimationStatus.completed) return;
+    final cb = _onAnimComplete;
+    _onAnimComplete = null;
+    cb?.call();
+  }
+
+  void _animateTo(
+    double to, {
+    required Duration duration,
+    Curve curve = Curves.easeOutCubic,
+    VoidCallback? onComplete,
+  }) {
+    _ctrl.stop();
+    _anim = Tween<double>(begin: _offset, end: to).animate(
+      CurvedAnimation(parent: _ctrl, curve: curve),
+    );
+    _onAnimComplete = onComplete;
+    _ctrl.duration = duration;
+    _ctrl.reset();
+    _ctrl.forward();
+  }
+
+  void _onDragUpdate(DragUpdateDetails details) {
+    if (_ctrl.isAnimating) return;
+    setState(() => _offset += details.delta.dx);
+  }
+
+  void _onDragEnd(DragEndDetails details) {
+    if (_ctrl.isAnimating) return;
+    final velocity = details.primaryVelocity ?? 0;
+    final width = context.size?.width ?? 400.0;
+
+    if (velocity < -500 || _offset < -width * 0.3) {
+      // 左スワイプ → 次の曲
+      _animateTo(
+        -width,
+        duration: const Duration(milliseconds: 200),
+        curve: Curves.easeInCubic,
+        onComplete: () {
+          widget.onNextSong();
+          setState(() => _offset = width); // 右端から入場
+          _animateTo(
+            0,
+            duration: const Duration(milliseconds: 280),
+            curve: Curves.easeOutCubic,
+          );
+        },
+      );
+    } else if (velocity > 500 || _offset > width * 0.3) {
+      // 右スワイプ → 前の曲
+      _animateTo(
+        width,
+        duration: const Duration(milliseconds: 200),
+        curve: Curves.easeInCubic,
+        onComplete: () {
+          widget.onPreviousSong();
+          setState(() => _offset = -width); // 左端から入場
+          _animateTo(
+            0,
+            duration: const Duration(milliseconds: 280),
+            curve: Curves.easeOutCubic,
+          );
+        },
+      );
+    } else {
+      // 不十分なスワイプ → 元に戻す
+      _animateTo(
+        0,
+        duration: const Duration(milliseconds: 300),
+        curve: Curves.easeOutCubic,
+      );
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 32),
-      child: GestureDetector(
-        onHorizontalDragEnd: (details) {
-          if (details.primaryVelocity != null && details.primaryVelocity! < 0) {
-            onNextSong();
-          } else if (details.primaryVelocity != null &&
-              details.primaryVelocity! > 0) {
-            onPreviousSong();
-          }
-        },
-        child: Container(
-          width: double.infinity,
-          height: 240,
-          decoration: BoxDecoration(
-            color: albumColor,
-            borderRadius: BorderRadius.circular(12),
-            border: highlightSwipe
-                ? Border.all(
-                    color: ext.highlightBorderColor,
-                    width: 3,
-                  )
-                : null,
-          ),
-          child: Center(
-            child: Icon(albumIcon, size: 96, color: ext.onAlbumColor.withValues(alpha: 0.7)),
+      child: ClipRect(
+        child: GestureDetector(
+          onHorizontalDragUpdate: _onDragUpdate,
+          onHorizontalDragEnd: _onDragEnd,
+          child: Transform.translate(
+            offset: Offset(_offset, 0),
+            child: Container(
+              width: double.infinity,
+              height: 240,
+              decoration: BoxDecoration(
+                color: widget.albumColor,
+                borderRadius: BorderRadius.circular(12),
+                border: widget.highlightSwipe
+                    ? Border.all(
+                        color: widget.ext.highlightBorderColor,
+                        width: 3,
+                      )
+                    : null,
+              ),
+              child: Center(
+                child: Icon(
+                  widget.albumIcon,
+                  size: 96,
+                  color: widget.ext.onAlbumColor.withValues(alpha: 0.7),
+                ),
+              ),
+            ),
           ),
         ),
       ),
@@ -594,9 +789,9 @@ class _PlaybackControls extends StatelessWidget {
   }
 }
 
-// ─── 歌詞パネル ────────────────────────────────────────────────────────────────
+// ─── 歌詞パネル（ヘッダードラッグ対応） ────────────────────────────────────────
 
-class _LyricsPanel extends StatelessWidget {
+class _LyricsPanel extends StatefulWidget {
   const _LyricsPanel({
     required this.ext,
     required this.lyrics,
@@ -610,50 +805,86 @@ class _LyricsPanel extends StatelessWidget {
   final bool highlightLyrics;
 
   @override
+  State<_LyricsPanel> createState() => _LyricsPanelState();
+}
+
+class _LyricsPanelState extends State<_LyricsPanel> {
+  final _sheetController = DraggableScrollableController();
+
+  @override
+  void dispose() {
+    _sheetController.dispose();
+    super.dispose();
+  }
+
+  void _onHeaderDragUpdate(DragUpdateDetails details) {
+    if (!_sheetController.isAttached) return;
+    final screenHeight = MediaQuery.heightOf(context);
+    final delta = -details.delta.dy / screenHeight;
+    final newSize = (_sheetController.size + delta).clamp(0.08, 1.0);
+    _sheetController.jumpTo(newSize);
+  }
+
+  @override
   Widget build(BuildContext context) {
     final sq = context.sq;
     return DraggableScrollableSheet(
+      controller: _sheetController,
       initialChildSize: 0.12,
       minChildSize: 0.08,
       maxChildSize: 1.0,
       builder: (context, scrollController) {
         return NotificationListener<DraggableScrollableNotification>(
           onNotification: (notification) {
-            onLyricsSizeChanged(notification.extent);
+            widget.onLyricsSizeChanged(notification.extent);
             return false;
           },
           child: Container(
             decoration: BoxDecoration(
-              color: ext.cardBackground,
+              color: widget.ext.cardBackground,
               borderRadius: const BorderRadius.vertical(top: Radius.circular(16)),
-              border: highlightLyrics
-                  ? Border.all(color: ext.highlightBorderColor, width: 2)
+              border: widget.highlightLyrics
+                  ? Border.all(color: widget.ext.highlightBorderColor, width: 2)
                   : null,
             ),
             child: Column(
               children: [
-                const SizedBox(height: 8),
-                Container(
-                  width: 40,
-                  height: 4,
-                  decoration: BoxDecoration(
-                    color: ext.inactiveColor,
-                    borderRadius: BorderRadius.circular(2),
-                  ),
-                ),
-                Padding(
-                  padding: const EdgeInsets.symmetric(vertical: 8),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
+                // ヘッダー領域：ドラッグでシートを展開・縮小できる
+                GestureDetector(
+                  behavior: HitTestBehavior.opaque,
+                  onVerticalDragUpdate: _onHeaderDragUpdate,
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
                     children: [
-                      Icon(Icons.lyrics_outlined, color: ext.subTextColor, size: 16),
-                      const SizedBox(width: 4),
-                      UnreadableText(
-                        sq.common.lyrics,
-                        style: TextStyle(
-                          color: ext.subTextColor,
-                          fontSize: 13,
-                          fontWeight: FontWeight.w600,
+                      const SizedBox(height: 8),
+                      Container(
+                        width: 40,
+                        height: 4,
+                        decoration: BoxDecoration(
+                          color: widget.ext.inactiveColor,
+                          borderRadius: BorderRadius.circular(2),
+                        ),
+                      ),
+                      Padding(
+                        padding: const EdgeInsets.symmetric(vertical: 8),
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            Icon(
+                              Icons.lyrics_outlined,
+                              color: widget.ext.subTextColor,
+                              size: 16,
+                            ),
+                            const SizedBox(width: 4),
+                            UnreadableText(
+                              sq.common.lyrics,
+                              style: TextStyle(
+                                color: widget.ext.subTextColor,
+                                fontSize: 13,
+                                fontWeight: FontWeight.w600,
+                              ),
+                            ),
+                          ],
                         ),
                       ),
                     ],
@@ -663,19 +894,19 @@ class _LyricsPanel extends StatelessWidget {
                   child: SingleChildScrollView(
                     controller: scrollController,
                     padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 8),
-                    child: lyrics.isEmpty
+                    child: widget.lyrics.isEmpty
                         ? Text(
                             sq.common.lyricsNotAvailable,
                             style: TextStyle(
-                              color: ext.subTextColor,
+                              color: widget.ext.subTextColor,
                               fontSize: 14,
                             ),
                             textAlign: TextAlign.center,
                           )
                         : Text(
-                            lyrics,
+                            widget.lyrics,
                             style: TextStyle(
-                              color: ext.primaryTextColor,
+                              color: widget.ext.primaryTextColor,
                               fontSize: 16,
                               height: 1.8,
                             ),

--- a/packages/quizzes/music/lib/src/presentation/music_app_scaffold.dart
+++ b/packages/quizzes/music/lib/src/presentation/music_app_scaffold.dart
@@ -174,7 +174,7 @@ class _HomeBackground extends StatelessWidget {
                       color: color,
                       borderRadius: BorderRadius.circular(4),
                     ),
-                    child: Icon(icon, color: Colors.white, size: 24),
+                    child: Icon(icon, color: ext.onAlbumColor, size: 24),
                   ),
                   title: UnreadableText(
                     song.title,
@@ -413,7 +413,7 @@ class _ArtworkArea extends StatelessWidget {
                 : null,
           ),
           child: Center(
-            child: Icon(albumIcon, size: 96, color: Colors.white70),
+            child: Icon(albumIcon, size: 96, color: ext.onAlbumColor.withValues(alpha: 0.7)),
           ),
         ),
       ),
@@ -493,6 +493,7 @@ class _PlaybackControls extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final sq = context.sq;
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 24),
       child: Column(
@@ -518,11 +519,11 @@ class _PlaybackControls extends StatelessWidget {
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
                 Text(
-                  '1:12',
+                  sq.common.mockCurrentTime,
                   style: TextStyle(color: ext.subTextColor, fontSize: 12),
                 ),
                 Text(
-                  '3:45',
+                  sq.common.mockDuration,
                   style: TextStyle(color: ext.subTextColor, fontSize: 12),
                 ),
               ],
@@ -552,7 +553,7 @@ class _PlaybackControls extends StatelessWidget {
                   ),
                   child: Icon(
                     isPlaying ? Icons.pause : Icons.play_arrow,
-                    color: Colors.white,
+                    color: ext.onAlbumColor,
                     size: 36,
                   ),
                 ),
@@ -734,7 +735,7 @@ class _MiniPlayer extends StatelessWidget {
                   color: albumColor,
                   borderRadius: BorderRadius.circular(4),
                 ),
-                child: Icon(albumIcon, color: Colors.white, size: 24),
+                child: Icon(albumIcon, color: ext.onAlbumColor, size: 24),
               ),
               const SizedBox(width: 12),
               Expanded(

--- a/packages/quizzes/music/lib/src/presentation/music_app_state.dart
+++ b/packages/quizzes/music/lib/src/presentation/music_app_state.dart
@@ -1,0 +1,61 @@
+import 'package:just_audio/just_audio.dart';
+
+class MusicAppState {
+  const MusicAppState({
+    required this.isPlayerExpanded,
+    required this.currentSongIndex,
+    required this.repeatMode,
+    required this.isPlaying,
+    required this.lyricsSheetSize,
+  });
+
+  final bool isPlayerExpanded;
+  final int currentSongIndex;
+  final LoopMode repeatMode;
+  final bool isPlaying;
+  final double lyricsSheetSize;
+
+  static const initial = MusicAppState(
+    isPlayerExpanded: true,
+    currentSongIndex: 0,
+    repeatMode: LoopMode.off,
+    isPlaying: true,
+    lyricsSheetSize: 0.0,
+  );
+
+  MusicAppState copyWith({
+    bool? isPlayerExpanded,
+    int? currentSongIndex,
+    LoopMode? repeatMode,
+    bool? isPlaying,
+    double? lyricsSheetSize,
+  }) {
+    return MusicAppState(
+      isPlayerExpanded: isPlayerExpanded ?? this.isPlayerExpanded,
+      currentSongIndex: currentSongIndex ?? this.currentSongIndex,
+      repeatMode: repeatMode ?? this.repeatMode,
+      isPlaying: isPlaying ?? this.isPlaying,
+      lyricsSheetSize: lyricsSheetSize ?? this.lyricsSheetSize,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is MusicAppState &&
+          runtimeType == other.runtimeType &&
+          isPlayerExpanded == other.isPlayerExpanded &&
+          currentSongIndex == other.currentSongIndex &&
+          repeatMode == other.repeatMode &&
+          isPlaying == other.isPlaying &&
+          lyricsSheetSize == other.lyricsSheetSize;
+
+  @override
+  int get hashCode => Object.hash(
+        isPlayerExpanded,
+        currentSongIndex,
+        repeatMode,
+        isPlaying,
+        lyricsSheetSize,
+      );
+}

--- a/packages/quizzes/music/lib/src/presentation/quiz1_next_song/next_song_quiz_notifier.dart
+++ b/packages/quizzes/music/lib/src/presentation/quiz1_next_song/next_song_quiz_notifier.dart
@@ -29,28 +29,29 @@ class NextSongQuizNotifier extends AutoDisposeNotifier<NextSongQuizState> {
       _timer?.cancel();
       _player?.dispose();
     });
-    _initPlayer();
     return NextSongQuizState.initial();
   }
 
   void _initPlayer() {
     try {
-      _player = AudioPlayer();
-      _player!.setLoopMode(LoopMode.off);
+      final player = AudioPlayer();
+      player.setLoopMode(LoopMode.off);
       final source = ConcatenatingAudioSource(
         children: [
           AudioSource.asset(MusicCatalog.audioPaths[0]),
           AudioSource.asset(MusicCatalog.audioPaths[1]),
         ],
       );
-      _player!.setAudioSource(source).then((_) {
-        _player!.play();
+      _player = player;
+      player.setAudioSource(source).then((_) {
+        player.play();
       }).catchError((_) {});
     } catch (_) {}
   }
 
   void startQuiz() {
     if (state.status != QuizStatus.idle) return;
+    _initPlayer();
     state = NextSongQuizState.initial().copyWith(
       status: QuizStatus.playing,
       startedAt: clock.now(),
@@ -82,7 +83,15 @@ class NextSongQuizNotifier extends AutoDisposeNotifier<NextSongQuizState> {
         elapsedMs: elapsed,
       );
       unawaited(hapticFeedback.playSuccessFeedback());
-      await _saveResult(isCleared: true, elapsedMs: elapsed);
+      try {
+        await _saveResult(isCleared: true, elapsedMs: elapsed);
+      } catch (error, stackTrace) {
+        appLogger.e(
+          'Failed to save correct result',
+          error: error,
+          stackTrace: stackTrace,
+        );
+      }
     } else {
       state = state.copyWith(
         musicState: state.musicState.copyWith(currentSongIndex: nextIndex),
@@ -137,6 +146,7 @@ class NextSongQuizNotifier extends AutoDisposeNotifier<NextSongQuizState> {
 
   void updateLyricsSize(double size) {
     if (state.status != QuizStatus.playing) return;
+    if ((size - state.musicState.lyricsSheetSize).abs() < 0.01) return;
     state = state.copyWith(
       musicState: state.musicState.copyWith(lyricsSheetSize: size),
     );
@@ -169,8 +179,9 @@ class NextSongQuizNotifier extends AutoDisposeNotifier<NextSongQuizState> {
 
   void retry() {
     _timer?.cancel();
+    _player?.dispose();
+    _player = null;
     ref.read(analyticsServiceProvider).logQuizRetried(quizId: _quizId);
-    _initPlayer();
     state = NextSongQuizState.initial();
   }
 

--- a/packages/quizzes/music/lib/src/presentation/quiz1_next_song/next_song_quiz_notifier.dart
+++ b/packages/quizzes/music/lib/src/presentation/quiz1_next_song/next_song_quiz_notifier.dart
@@ -39,8 +39,8 @@ class NextSongQuizNotifier extends AutoDisposeNotifier<NextSongQuizState> {
       _player!.setLoopMode(LoopMode.off);
       final source = ConcatenatingAudioSource(
         children: [
-          AudioSource.asset(MusicCatalog.songs[0].audioAssetPath),
-          AudioSource.asset(MusicCatalog.songs[1].audioAssetPath),
+          AudioSource.asset(MusicCatalog.audioPaths[0]),
+          AudioSource.asset(MusicCatalog.audioPaths[1]),
         ],
       );
       _player!.setAudioSource(source).then((_) {
@@ -62,7 +62,7 @@ class NextSongQuizNotifier extends AutoDisposeNotifier<NextSongQuizState> {
   Future<void> nextSong() async {
     if (state.status != QuizStatus.playing) return;
     final previousIndex = state.musicState.currentSongIndex;
-    final nextIndex = (previousIndex + 1) % MusicCatalog.songs.length;
+    final nextIndex = (previousIndex + 1) % MusicCatalog.songCount;
 
     await _player?.seekToNext();
 
@@ -93,8 +93,8 @@ class NextSongQuizNotifier extends AutoDisposeNotifier<NextSongQuizState> {
   Future<void> previousSong() async {
     if (state.status != QuizStatus.playing) return;
     final prevIndex =
-        (state.musicState.currentSongIndex - 1 + MusicCatalog.songs.length) %
-        MusicCatalog.songs.length;
+        (state.musicState.currentSongIndex - 1 + MusicCatalog.songCount) %
+        MusicCatalog.songCount;
     await _player?.seekToPrevious();
     state = state.copyWith(
       musicState: state.musicState.copyWith(currentSongIndex: prevIndex),

--- a/packages/quizzes/music/lib/src/presentation/quiz1_next_song/next_song_quiz_notifier.dart
+++ b/packages/quizzes/music/lib/src/presentation/quiz1_next_song/next_song_quiz_notifier.dart
@@ -1,0 +1,233 @@
+import 'dart:async';
+
+import 'package:clock/clock.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:just_audio/just_audio.dart';
+import 'package:quiz_core/quiz_core.dart';
+import 'package:system/system.dart';
+
+import '../../application/quiz_next_song_use_case.dart';
+import '../../domain/music_catalog.dart';
+import '../../infrastructure/music_quiz_repository_provider.dart';
+import 'next_song_quiz_state.dart';
+
+final nextSongQuizProvider =
+    AutoDisposeNotifierProvider<NextSongQuizNotifier, NextSongQuizState>(
+  NextSongQuizNotifier.new,
+);
+
+class NextSongQuizNotifier extends AutoDisposeNotifier<NextSongQuizState> {
+  static const _quizId = 'music_quiz1';
+
+  final _useCase = const QuizNextSongUseCase();
+  AudioPlayer? _player;
+  Timer? _timer;
+
+  @override
+  NextSongQuizState build() {
+    ref.onDispose(() {
+      _timer?.cancel();
+      _player?.dispose();
+    });
+    _initPlayer();
+    return NextSongQuizState.initial();
+  }
+
+  void _initPlayer() {
+    try {
+      _player = AudioPlayer();
+      _player!.setLoopMode(LoopMode.off);
+      final source = ConcatenatingAudioSource(
+        children: [
+          AudioSource.asset(MusicCatalog.songs[0].audioAssetPath),
+          AudioSource.asset(MusicCatalog.songs[1].audioAssetPath),
+        ],
+      );
+      _player!.setAudioSource(source).then((_) {
+        _player!.play();
+      }).catchError((_) {});
+    } catch (_) {}
+  }
+
+  void startQuiz() {
+    if (state.status != QuizStatus.idle) return;
+    state = NextSongQuizState.initial().copyWith(
+      status: QuizStatus.playing,
+      startedAt: clock.now(),
+    );
+    ref.read(analyticsServiceProvider).logQuizStarted(quizId: _quizId);
+    _startTimer();
+  }
+
+  Future<void> nextSong() async {
+    if (state.status != QuizStatus.playing) return;
+    final previousIndex = state.musicState.currentSongIndex;
+    final nextIndex = (previousIndex + 1) % MusicCatalog.songs.length;
+
+    await _player?.seekToNext();
+
+    final isClear = _useCase.isClear(
+      previousIndex: previousIndex,
+      currentIndex: nextIndex,
+    );
+
+    if (isClear) {
+      _timer?.cancel();
+      final elapsed = state.startedAt != null
+          ? clock.now().difference(state.startedAt!).inMilliseconds
+          : 0;
+      state = state.copyWith(
+        musicState: state.musicState.copyWith(currentSongIndex: nextIndex),
+        status: QuizStatus.correct,
+        elapsedMs: elapsed,
+      );
+      unawaited(hapticFeedback.playSuccessFeedback());
+      await _saveResult(isCleared: true, elapsedMs: elapsed);
+    } else {
+      state = state.copyWith(
+        musicState: state.musicState.copyWith(currentSongIndex: nextIndex),
+      );
+    }
+  }
+
+  Future<void> previousSong() async {
+    if (state.status != QuizStatus.playing) return;
+    final prevIndex =
+        (state.musicState.currentSongIndex - 1 + MusicCatalog.songs.length) %
+        MusicCatalog.songs.length;
+    await _player?.seekToPrevious();
+    state = state.copyWith(
+      musicState: state.musicState.copyWith(currentSongIndex: prevIndex),
+    );
+  }
+
+  void togglePlayPause() {
+    if (state.status != QuizStatus.playing) return;
+    if (state.musicState.isPlaying) {
+      _player?.pause();
+    } else {
+      _player?.play();
+    }
+    state = state.copyWith(
+      musicState: state.musicState.copyWith(
+        isPlaying: !state.musicState.isPlaying,
+      ),
+    );
+  }
+
+  void togglePlayerExpansion(bool expanded) {
+    if (state.status != QuizStatus.playing) return;
+    state = state.copyWith(
+      musicState: state.musicState.copyWith(isPlayerExpanded: expanded),
+    );
+  }
+
+  void cycleRepeatMode() {
+    if (state.status != QuizStatus.playing) return;
+    final nextMode = switch (state.musicState.repeatMode) {
+      LoopMode.off => LoopMode.all,
+      LoopMode.all => LoopMode.one,
+      LoopMode.one => LoopMode.off,
+    };
+    _player?.setLoopMode(nextMode);
+    state = state.copyWith(
+      musicState: state.musicState.copyWith(repeatMode: nextMode),
+    );
+  }
+
+  void updateLyricsSize(double size) {
+    if (state.status != QuizStatus.playing) return;
+    state = state.copyWith(
+      musicState: state.musicState.copyWith(lyricsSheetSize: size),
+    );
+  }
+
+  Future<void> giveUp() async {
+    if (state.status != QuizStatus.playing) return;
+    _timer?.cancel();
+    final elapsed = state.startedAt != null
+        ? clock.now().difference(state.startedAt!).inMilliseconds
+        : 0;
+    state = state.copyWith(
+      status: QuizStatus.giveUp,
+      remainingSeconds: 0,
+      elapsedMs: elapsed,
+    );
+    unawaited(
+      ref.read(analyticsServiceProvider).logQuizGivenUp(quizId: _quizId),
+    );
+    try {
+      await _saveResult(isCleared: false, elapsedMs: elapsed);
+    } catch (error, stackTrace) {
+      appLogger.e(
+        'Failed to save giveUp result',
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
+  }
+
+  void retry() {
+    _timer?.cancel();
+    ref.read(analyticsServiceProvider).logQuizRetried(quizId: _quizId);
+    _initPlayer();
+    state = NextSongQuizState.initial();
+  }
+
+  void _startTimer() {
+    _timer?.cancel();
+    _timer = Timer.periodic(const Duration(seconds: 1), (_) {
+      final remaining = state.remainingSeconds - 1;
+      if (remaining <= 0) {
+        _timer?.cancel();
+        _onTimeUp();
+      } else {
+        state = state.copyWith(remainingSeconds: remaining);
+      }
+    });
+  }
+
+  Future<void> _onTimeUp() async {
+    final elapsed = state.startedAt != null
+        ? clock.now().difference(state.startedAt!).inMilliseconds
+        : 0;
+    state = state.copyWith(
+      status: QuizStatus.timeUp,
+      remainingSeconds: 0,
+      elapsedMs: elapsed,
+    );
+    try {
+      await _saveResult(isCleared: false, elapsedMs: elapsed);
+    } catch (error, stackTrace) {
+      appLogger.e(
+        'Failed to save timeUp result',
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
+  }
+
+  Future<void> _saveResult({
+    required bool isCleared,
+    required int elapsedMs,
+  }) async {
+    final repo = ref.read(musicQuizRepositoryProvider);
+    await repo.saveResult(
+      quizId: _quizId,
+      isCleared: isCleared,
+      clearTimeMs: isCleared ? elapsedMs : null,
+      score: isCleared ? state.score : 0,
+      failureCount: state.failureCount,
+    );
+    if (isCleared) {
+      unawaited(
+        ref.read(analyticsServiceProvider).logQuizCompleted(
+              quizId: _quizId,
+              score: state.score,
+              failureCount: state.failureCount,
+              clearTimeMs: elapsedMs,
+            ),
+      );
+    }
+  }
+}

--- a/packages/quizzes/music/lib/src/presentation/quiz1_next_song/next_song_quiz_screen.dart
+++ b/packages/quizzes/music/lib/src/presentation/quiz1_next_song/next_song_quiz_screen.dart
@@ -29,7 +29,7 @@ class _NextSongQuizScreenState extends ConsumerState<NextSongQuizScreen> {
 
     return MusicAppScaffold(
       musicState: state.musicState,
-      songs: MusicCatalog.songs,
+      songs: MusicCatalog.buildSongs(context.sq),
       quizStatus: state.status,
       remainingSeconds: state.remainingSeconds,
       timeLimitSeconds: MusicQuizConfig.quiz1TimeLimitSeconds,

--- a/packages/quizzes/music/lib/src/presentation/quiz1_next_song/next_song_quiz_screen.dart
+++ b/packages/quizzes/music/lib/src/presentation/quiz1_next_song/next_song_quiz_screen.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:quiz_core/quiz_core.dart';
+import 'package:system/system.dart';
+
+import '../../domain/music_catalog.dart';
+import '../../domain/music_quiz_config.dart';
+import '../../i18n/music_translations_extension.dart';
+import '../music_app_scaffold.dart';
+import 'next_song_quiz_notifier.dart';
+
+class NextSongQuizScreen extends ConsumerStatefulWidget {
+  const NextSongQuizScreen({super.key, this.onCompleted});
+
+  final VoidCallback? onCompleted;
+
+  @override
+  ConsumerState<NextSongQuizScreen> createState() => _NextSongQuizScreenState();
+}
+
+class _NextSongQuizScreenState extends ConsumerState<NextSongQuizScreen> {
+  bool _showCutIn = true;
+  bool _hintUsed = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(nextSongQuizProvider);
+    final missionText = context.s.quiz1.missionText;
+
+    return MusicAppScaffold(
+      musicState: state.musicState,
+      songs: MusicCatalog.songs,
+      quizStatus: state.status,
+      remainingSeconds: state.remainingSeconds,
+      timeLimitSeconds: MusicQuizConfig.quiz1TimeLimitSeconds,
+      missionText: missionText,
+      onGiveUp: () => ref.read(nextSongQuizProvider.notifier).giveUp(),
+      onTogglePlayPause: () =>
+          ref.read(nextSongQuizProvider.notifier).togglePlayPause(),
+      onNextSong: () => ref.read(nextSongQuizProvider.notifier).nextSong(),
+      onPreviousSong: () =>
+          ref.read(nextSongQuizProvider.notifier).previousSong(),
+      onTogglePlayerExpansion: (expanded) =>
+          ref.read(nextSongQuizProvider.notifier).togglePlayerExpansion(expanded),
+      onCycleRepeatMode: () =>
+          ref.read(nextSongQuizProvider.notifier).cycleRepeatMode(),
+      onLyricsSizeChanged: (size) =>
+          ref.read(nextSongQuizProvider.notifier).updateLyricsSize(size),
+      hintUsed: _hintUsed,
+      onHintTap: () => setState(() => _hintUsed = true),
+      highlightSwipe: _hintUsed && state.status == QuizStatus.playing,
+      overlays: [
+        if (_showCutIn)
+          MissionCutIn(
+            missionText: missionText,
+            timeLimitSeconds: MusicQuizConfig.quiz1TimeLimitSeconds,
+            onFinished: () {
+              if (!mounted) return;
+              setState(() => _showCutIn = false);
+              ref.read(nextSongQuizProvider.notifier).startQuiz();
+            },
+          ),
+        if (state.status == QuizStatus.correct ||
+            state.status == QuizStatus.incorrect ||
+            state.status == QuizStatus.timeUp ||
+            state.status == QuizStatus.giveUp)
+          Positioned.fill(
+            child: QuizResultOverlay(
+              status: state.status,
+              score: state.score,
+              elapsedMs: state.elapsedMs,
+              onRetry: () {
+                setState(() {
+                  _showCutIn = true;
+                  _hintUsed = false;
+                });
+                ref.read(nextSongQuizProvider.notifier).retry();
+              },
+              onNext: state.status == QuizStatus.correct
+                  ? widget.onCompleted
+                  : null,
+              onBack: () => Navigator.of(context).pop(),
+              isLimitReached: ref.isPlayLimitReached,
+              insight: Builder(
+                builder: (context) {
+                  final insight = context.s.quiz1.insight;
+                  return QuizInsightContent(
+                    title: insight.title,
+                    subtitle: insight.subtitle,
+                    items: [
+                      QuizInsightItem(
+                        emoji: '👈',
+                        title: insight.swipeTitle,
+                        desc: insight.swipeDesc,
+                      ),
+                      QuizInsightItem(
+                        emoji: '⏭',
+                        title: insight.skipTitle,
+                        desc: insight.skipDesc,
+                      ),
+                      QuizInsightItem(
+                        emoji: '✌️',
+                        title: insight.gestureTitle,
+                        desc: insight.gestureDesc,
+                      ),
+                    ],
+                  );
+                },
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}

--- a/packages/quizzes/music/lib/src/presentation/quiz1_next_song/next_song_quiz_screen.dart
+++ b/packages/quizzes/music/lib/src/presentation/quiz1_next_song/next_song_quiz_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:quiz_core/quiz_core.dart';
 import 'package:system/system.dart';
 
+import '../../domain/entities/music_song.dart';
 import '../../domain/music_catalog.dart';
 import '../../domain/music_quiz_config.dart';
 import '../../i18n/music_translations_extension.dart';
@@ -21,6 +22,13 @@ class NextSongQuizScreen extends ConsumerStatefulWidget {
 class _NextSongQuizScreenState extends ConsumerState<NextSongQuizScreen> {
   bool _showCutIn = true;
   bool _hintUsed = false;
+  late List<MusicSong> _songs;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _songs = MusicCatalog.buildSongs(context.sq);
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -29,7 +37,7 @@ class _NextSongQuizScreenState extends ConsumerState<NextSongQuizScreen> {
 
     return MusicAppScaffold(
       musicState: state.musicState,
-      songs: MusicCatalog.buildSongs(context.sq),
+      songs: _songs,
       quizStatus: state.status,
       remainingSeconds: state.remainingSeconds,
       timeLimitSeconds: MusicQuizConfig.quiz1TimeLimitSeconds,

--- a/packages/quizzes/music/lib/src/presentation/quiz1_next_song/next_song_quiz_state.dart
+++ b/packages/quizzes/music/lib/src/presentation/quiz1_next_song/next_song_quiz_state.dart
@@ -1,0 +1,45 @@
+import 'package:quiz_core/quiz_core.dart';
+
+import '../../domain/music_quiz_config.dart';
+import '../music_app_state.dart';
+
+class NextSongQuizState extends QuizStateBase {
+  const NextSongQuizState({
+    required super.status,
+    required super.failureCount,
+    required super.elapsedMs,
+    required super.startedAt,
+    required this.musicState,
+    required this.remainingSeconds,
+  });
+
+  final MusicAppState musicState;
+  final int remainingSeconds;
+
+  NextSongQuizState copyWith({
+    QuizStatus? status,
+    int? failureCount,
+    int? elapsedMs,
+    DateTime? startedAt,
+    MusicAppState? musicState,
+    int? remainingSeconds,
+  }) {
+    return NextSongQuizState(
+      status: status ?? this.status,
+      failureCount: failureCount ?? this.failureCount,
+      elapsedMs: elapsedMs ?? this.elapsedMs,
+      startedAt: startedAt ?? this.startedAt,
+      musicState: musicState ?? this.musicState,
+      remainingSeconds: remainingSeconds ?? this.remainingSeconds,
+    );
+  }
+
+  factory NextSongQuizState.initial() => const NextSongQuizState(
+        status: QuizStatus.idle,
+        failureCount: 0,
+        elapsedMs: 0,
+        startedAt: null,
+        musicState: MusicAppState.initial,
+        remainingSeconds: MusicQuizConfig.quiz1TimeLimitSeconds,
+      );
+}

--- a/packages/quizzes/music/lib/src/presentation/quiz2_minimize_player/minimize_player_quiz_notifier.dart
+++ b/packages/quizzes/music/lib/src/presentation/quiz2_minimize_player/minimize_player_quiz_notifier.dart
@@ -40,8 +40,8 @@ class MinimizePlayerQuizNotifier
       _player!.setLoopMode(LoopMode.off);
       final source = ConcatenatingAudioSource(
         children: [
-          AudioSource.asset(MusicCatalog.songs[0].audioAssetPath),
-          AudioSource.asset(MusicCatalog.songs[1].audioAssetPath),
+          AudioSource.asset(MusicCatalog.audioPaths[0]),
+          AudioSource.asset(MusicCatalog.audioPaths[1]),
         ],
       );
       _player!.setAudioSource(source).then((_) {
@@ -63,7 +63,7 @@ class MinimizePlayerQuizNotifier
   Future<void> nextSong() async {
     if (state.status != QuizStatus.playing) return;
     final nextIndex =
-        (state.musicState.currentSongIndex + 1) % MusicCatalog.songs.length;
+        (state.musicState.currentSongIndex + 1) % MusicCatalog.songCount;
     await _player?.seekToNext();
     state = state.copyWith(
       musicState: state.musicState.copyWith(currentSongIndex: nextIndex),
@@ -73,8 +73,8 @@ class MinimizePlayerQuizNotifier
   Future<void> previousSong() async {
     if (state.status != QuizStatus.playing) return;
     final prevIndex =
-        (state.musicState.currentSongIndex - 1 + MusicCatalog.songs.length) %
-        MusicCatalog.songs.length;
+        (state.musicState.currentSongIndex - 1 + MusicCatalog.songCount) %
+        MusicCatalog.songCount;
     await _player?.seekToPrevious();
     state = state.copyWith(
       musicState: state.musicState.copyWith(currentSongIndex: prevIndex),

--- a/packages/quizzes/music/lib/src/presentation/quiz2_minimize_player/minimize_player_quiz_notifier.dart
+++ b/packages/quizzes/music/lib/src/presentation/quiz2_minimize_player/minimize_player_quiz_notifier.dart
@@ -1,0 +1,230 @@
+import 'dart:async';
+
+import 'package:clock/clock.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:just_audio/just_audio.dart';
+import 'package:quiz_core/quiz_core.dart';
+import 'package:system/system.dart';
+
+import '../../application/quiz_minimize_player_use_case.dart';
+import '../../domain/music_catalog.dart';
+import '../../infrastructure/music_quiz_repository_provider.dart';
+import 'minimize_player_quiz_state.dart';
+
+final minimizePlayerQuizProvider = AutoDisposeNotifierProvider<
+    MinimizePlayerQuizNotifier, MinimizePlayerQuizState>(
+  MinimizePlayerQuizNotifier.new,
+);
+
+class MinimizePlayerQuizNotifier
+    extends AutoDisposeNotifier<MinimizePlayerQuizState> {
+  static const _quizId = 'music_quiz2';
+
+  final _useCase = const QuizMinimizePlayerUseCase();
+  AudioPlayer? _player;
+  Timer? _timer;
+
+  @override
+  MinimizePlayerQuizState build() {
+    ref.onDispose(() {
+      _timer?.cancel();
+      _player?.dispose();
+    });
+    _initPlayer();
+    return MinimizePlayerQuizState.initial();
+  }
+
+  void _initPlayer() {
+    try {
+      _player = AudioPlayer();
+      _player!.setLoopMode(LoopMode.off);
+      final source = ConcatenatingAudioSource(
+        children: [
+          AudioSource.asset(MusicCatalog.songs[0].audioAssetPath),
+          AudioSource.asset(MusicCatalog.songs[1].audioAssetPath),
+        ],
+      );
+      _player!.setAudioSource(source).then((_) {
+        _player!.play();
+      }).catchError((_) {});
+    } catch (_) {}
+  }
+
+  void startQuiz() {
+    if (state.status != QuizStatus.idle) return;
+    state = MinimizePlayerQuizState.initial().copyWith(
+      status: QuizStatus.playing,
+      startedAt: clock.now(),
+    );
+    ref.read(analyticsServiceProvider).logQuizStarted(quizId: _quizId);
+    _startTimer();
+  }
+
+  Future<void> nextSong() async {
+    if (state.status != QuizStatus.playing) return;
+    final nextIndex =
+        (state.musicState.currentSongIndex + 1) % MusicCatalog.songs.length;
+    await _player?.seekToNext();
+    state = state.copyWith(
+      musicState: state.musicState.copyWith(currentSongIndex: nextIndex),
+    );
+  }
+
+  Future<void> previousSong() async {
+    if (state.status != QuizStatus.playing) return;
+    final prevIndex =
+        (state.musicState.currentSongIndex - 1 + MusicCatalog.songs.length) %
+        MusicCatalog.songs.length;
+    await _player?.seekToPrevious();
+    state = state.copyWith(
+      musicState: state.musicState.copyWith(currentSongIndex: prevIndex),
+    );
+  }
+
+  void togglePlayPause() {
+    if (state.status != QuizStatus.playing) return;
+    if (state.musicState.isPlaying) {
+      _player?.pause();
+    } else {
+      _player?.play();
+    }
+    state = state.copyWith(
+      musicState: state.musicState.copyWith(
+        isPlaying: !state.musicState.isPlaying,
+      ),
+    );
+  }
+
+  Future<void> togglePlayerExpansion(bool expanded) async {
+    if (state.status != QuizStatus.playing) return;
+
+    final isClear = _useCase.isClear(isExpanded: expanded);
+
+    if (isClear) {
+      _timer?.cancel();
+      final elapsed = state.startedAt != null
+          ? clock.now().difference(state.startedAt!).inMilliseconds
+          : 0;
+      state = state.copyWith(
+        musicState: state.musicState.copyWith(isPlayerExpanded: expanded),
+        status: QuizStatus.correct,
+        elapsedMs: elapsed,
+      );
+      unawaited(hapticFeedback.playSuccessFeedback());
+      await _saveResult(isCleared: true, elapsedMs: elapsed);
+    } else {
+      state = state.copyWith(
+        musicState: state.musicState.copyWith(isPlayerExpanded: expanded),
+      );
+    }
+  }
+
+  void cycleRepeatMode() {
+    if (state.status != QuizStatus.playing) return;
+    final nextMode = switch (state.musicState.repeatMode) {
+      LoopMode.off => LoopMode.all,
+      LoopMode.all => LoopMode.one,
+      LoopMode.one => LoopMode.off,
+    };
+    _player?.setLoopMode(nextMode);
+    state = state.copyWith(
+      musicState: state.musicState.copyWith(repeatMode: nextMode),
+    );
+  }
+
+  void updateLyricsSize(double size) {
+    if (state.status != QuizStatus.playing) return;
+    state = state.copyWith(
+      musicState: state.musicState.copyWith(lyricsSheetSize: size),
+    );
+  }
+
+  Future<void> giveUp() async {
+    if (state.status != QuizStatus.playing) return;
+    _timer?.cancel();
+    final elapsed = state.startedAt != null
+        ? clock.now().difference(state.startedAt!).inMilliseconds
+        : 0;
+    state = state.copyWith(
+      status: QuizStatus.giveUp,
+      remainingSeconds: 0,
+      elapsedMs: elapsed,
+    );
+    unawaited(
+      ref.read(analyticsServiceProvider).logQuizGivenUp(quizId: _quizId),
+    );
+    try {
+      await _saveResult(isCleared: false, elapsedMs: elapsed);
+    } catch (error, stackTrace) {
+      appLogger.e(
+        'Failed to save giveUp result',
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
+  }
+
+  void retry() {
+    _timer?.cancel();
+    ref.read(analyticsServiceProvider).logQuizRetried(quizId: _quizId);
+    _initPlayer();
+    state = MinimizePlayerQuizState.initial();
+  }
+
+  void _startTimer() {
+    _timer?.cancel();
+    _timer = Timer.periodic(const Duration(seconds: 1), (_) {
+      final remaining = state.remainingSeconds - 1;
+      if (remaining <= 0) {
+        _timer?.cancel();
+        _onTimeUp();
+      } else {
+        state = state.copyWith(remainingSeconds: remaining);
+      }
+    });
+  }
+
+  Future<void> _onTimeUp() async {
+    final elapsed = state.startedAt != null
+        ? clock.now().difference(state.startedAt!).inMilliseconds
+        : 0;
+    state = state.copyWith(
+      status: QuizStatus.timeUp,
+      remainingSeconds: 0,
+      elapsedMs: elapsed,
+    );
+    try {
+      await _saveResult(isCleared: false, elapsedMs: elapsed);
+    } catch (error, stackTrace) {
+      appLogger.e(
+        'Failed to save timeUp result',
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
+  }
+
+  Future<void> _saveResult({
+    required bool isCleared,
+    required int elapsedMs,
+  }) async {
+    final repo = ref.read(musicQuizRepositoryProvider);
+    await repo.saveResult(
+      quizId: _quizId,
+      isCleared: isCleared,
+      clearTimeMs: isCleared ? elapsedMs : null,
+      score: isCleared ? state.score : 0,
+      failureCount: state.failureCount,
+    );
+    if (isCleared) {
+      unawaited(
+        ref.read(analyticsServiceProvider).logQuizCompleted(
+              quizId: _quizId,
+              score: state.score,
+              failureCount: state.failureCount,
+              clearTimeMs: elapsedMs,
+            ),
+      );
+    }
+  }
+}

--- a/packages/quizzes/music/lib/src/presentation/quiz2_minimize_player/minimize_player_quiz_notifier.dart
+++ b/packages/quizzes/music/lib/src/presentation/quiz2_minimize_player/minimize_player_quiz_notifier.dart
@@ -30,28 +30,29 @@ class MinimizePlayerQuizNotifier
       _timer?.cancel();
       _player?.dispose();
     });
-    _initPlayer();
     return MinimizePlayerQuizState.initial();
   }
 
   void _initPlayer() {
     try {
-      _player = AudioPlayer();
-      _player!.setLoopMode(LoopMode.off);
+      final player = AudioPlayer();
+      player.setLoopMode(LoopMode.off);
       final source = ConcatenatingAudioSource(
         children: [
           AudioSource.asset(MusicCatalog.audioPaths[0]),
           AudioSource.asset(MusicCatalog.audioPaths[1]),
         ],
       );
-      _player!.setAudioSource(source).then((_) {
-        _player!.play();
+      _player = player;
+      player.setAudioSource(source).then((_) {
+        player.play();
       }).catchError((_) {});
     } catch (_) {}
   }
 
   void startQuiz() {
     if (state.status != QuizStatus.idle) return;
+    _initPlayer();
     state = MinimizePlayerQuizState.initial().copyWith(
       status: QuizStatus.playing,
       startedAt: clock.now(),
@@ -111,7 +112,15 @@ class MinimizePlayerQuizNotifier
         elapsedMs: elapsed,
       );
       unawaited(hapticFeedback.playSuccessFeedback());
-      await _saveResult(isCleared: true, elapsedMs: elapsed);
+      try {
+        await _saveResult(isCleared: true, elapsedMs: elapsed);
+      } catch (error, stackTrace) {
+        appLogger.e(
+          'Failed to save correct result',
+          error: error,
+          stackTrace: stackTrace,
+        );
+      }
     } else {
       state = state.copyWith(
         musicState: state.musicState.copyWith(isPlayerExpanded: expanded),
@@ -134,6 +143,7 @@ class MinimizePlayerQuizNotifier
 
   void updateLyricsSize(double size) {
     if (state.status != QuizStatus.playing) return;
+    if ((size - state.musicState.lyricsSheetSize).abs() < 0.01) return;
     state = state.copyWith(
       musicState: state.musicState.copyWith(lyricsSheetSize: size),
     );
@@ -166,8 +176,9 @@ class MinimizePlayerQuizNotifier
 
   void retry() {
     _timer?.cancel();
+    _player?.dispose();
+    _player = null;
     ref.read(analyticsServiceProvider).logQuizRetried(quizId: _quizId);
-    _initPlayer();
     state = MinimizePlayerQuizState.initial();
   }
 

--- a/packages/quizzes/music/lib/src/presentation/quiz2_minimize_player/minimize_player_quiz_screen.dart
+++ b/packages/quizzes/music/lib/src/presentation/quiz2_minimize_player/minimize_player_quiz_screen.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:quiz_core/quiz_core.dart';
+import 'package:system/system.dart';
+
+import '../../domain/music_catalog.dart';
+import '../../domain/music_quiz_config.dart';
+import '../../i18n/music_translations_extension.dart';
+import '../music_app_scaffold.dart';
+import 'minimize_player_quiz_notifier.dart';
+
+class MinimizePlayerQuizScreen extends ConsumerStatefulWidget {
+  const MinimizePlayerQuizScreen({super.key, this.onCompleted});
+
+  final VoidCallback? onCompleted;
+
+  @override
+  ConsumerState<MinimizePlayerQuizScreen> createState() =>
+      _MinimizePlayerQuizScreenState();
+}
+
+class _MinimizePlayerQuizScreenState
+    extends ConsumerState<MinimizePlayerQuizScreen> {
+  bool _showCutIn = true;
+  bool _hintUsed = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(minimizePlayerQuizProvider);
+    final missionText = context.s.quiz2.missionText;
+
+    return MusicAppScaffold(
+      musicState: state.musicState,
+      songs: MusicCatalog.songs,
+      quizStatus: state.status,
+      remainingSeconds: state.remainingSeconds,
+      timeLimitSeconds: MusicQuizConfig.quiz2TimeLimitSeconds,
+      missionText: missionText,
+      onGiveUp: () => ref.read(minimizePlayerQuizProvider.notifier).giveUp(),
+      onTogglePlayPause: () =>
+          ref.read(minimizePlayerQuizProvider.notifier).togglePlayPause(),
+      onNextSong: () =>
+          ref.read(minimizePlayerQuizProvider.notifier).nextSong(),
+      onPreviousSong: () =>
+          ref.read(minimizePlayerQuizProvider.notifier).previousSong(),
+      onTogglePlayerExpansion: (expanded) => ref
+          .read(minimizePlayerQuizProvider.notifier)
+          .togglePlayerExpansion(expanded),
+      onCycleRepeatMode: () =>
+          ref.read(minimizePlayerQuizProvider.notifier).cycleRepeatMode(),
+      onLyricsSizeChanged: (size) =>
+          ref.read(minimizePlayerQuizProvider.notifier).updateLyricsSize(size),
+      hintUsed: _hintUsed,
+      onHintTap: () => setState(() => _hintUsed = true),
+      highlightMinimize: _hintUsed && state.status == QuizStatus.playing,
+      overlays: [
+        if (_showCutIn)
+          MissionCutIn(
+            missionText: missionText,
+            timeLimitSeconds: MusicQuizConfig.quiz2TimeLimitSeconds,
+            onFinished: () {
+              if (!mounted) return;
+              setState(() => _showCutIn = false);
+              ref.read(minimizePlayerQuizProvider.notifier).startQuiz();
+            },
+          ),
+        if (state.status == QuizStatus.correct ||
+            state.status == QuizStatus.incorrect ||
+            state.status == QuizStatus.timeUp ||
+            state.status == QuizStatus.giveUp)
+          Positioned.fill(
+            child: QuizResultOverlay(
+              status: state.status,
+              score: state.score,
+              elapsedMs: state.elapsedMs,
+              onRetry: () {
+                setState(() {
+                  _showCutIn = true;
+                  _hintUsed = false;
+                });
+                ref.read(minimizePlayerQuizProvider.notifier).retry();
+              },
+              onNext: state.status == QuizStatus.correct
+                  ? widget.onCompleted
+                  : null,
+              onBack: () => Navigator.of(context).pop(),
+              isLimitReached: ref.isPlayLimitReached,
+              insight: Builder(
+                builder: (context) {
+                  final insight = context.s.quiz2.insight;
+                  return QuizInsightContent(
+                    title: insight.title,
+                    subtitle: insight.subtitle,
+                    items: [
+                      QuizInsightItem(
+                        emoji: '👇',
+                        title: insight.dragTitle,
+                        desc: insight.dragDesc,
+                      ),
+                      QuizInsightItem(
+                        emoji: '🎵',
+                        title: insight.miniTitle,
+                        desc: insight.miniDesc,
+                      ),
+                      QuizInsightItem(
+                        emoji: '〰️',
+                        title: insight.notchTitle,
+                        desc: insight.notchDesc,
+                      ),
+                    ],
+                  );
+                },
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}

--- a/packages/quizzes/music/lib/src/presentation/quiz2_minimize_player/minimize_player_quiz_screen.dart
+++ b/packages/quizzes/music/lib/src/presentation/quiz2_minimize_player/minimize_player_quiz_screen.dart
@@ -31,7 +31,7 @@ class _MinimizePlayerQuizScreenState
 
     return MusicAppScaffold(
       musicState: state.musicState,
-      songs: MusicCatalog.songs,
+      songs: MusicCatalog.buildSongs(context.sq),
       quizStatus: state.status,
       remainingSeconds: state.remainingSeconds,
       timeLimitSeconds: MusicQuizConfig.quiz2TimeLimitSeconds,

--- a/packages/quizzes/music/lib/src/presentation/quiz2_minimize_player/minimize_player_quiz_screen.dart
+++ b/packages/quizzes/music/lib/src/presentation/quiz2_minimize_player/minimize_player_quiz_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:quiz_core/quiz_core.dart';
 import 'package:system/system.dart';
 
+import '../../domain/entities/music_song.dart';
 import '../../domain/music_catalog.dart';
 import '../../domain/music_quiz_config.dart';
 import '../../i18n/music_translations_extension.dart';
@@ -23,6 +24,13 @@ class _MinimizePlayerQuizScreenState
     extends ConsumerState<MinimizePlayerQuizScreen> {
   bool _showCutIn = true;
   bool _hintUsed = false;
+  late List<MusicSong> _songs;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _songs = MusicCatalog.buildSongs(context.sq);
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -31,7 +39,7 @@ class _MinimizePlayerQuizScreenState
 
     return MusicAppScaffold(
       musicState: state.musicState,
-      songs: MusicCatalog.buildSongs(context.sq),
+      songs: _songs,
       quizStatus: state.status,
       remainingSeconds: state.remainingSeconds,
       timeLimitSeconds: MusicQuizConfig.quiz2TimeLimitSeconds,

--- a/packages/quizzes/music/lib/src/presentation/quiz2_minimize_player/minimize_player_quiz_state.dart
+++ b/packages/quizzes/music/lib/src/presentation/quiz2_minimize_player/minimize_player_quiz_state.dart
@@ -1,0 +1,45 @@
+import 'package:quiz_core/quiz_core.dart';
+
+import '../../domain/music_quiz_config.dart';
+import '../music_app_state.dart';
+
+class MinimizePlayerQuizState extends QuizStateBase {
+  const MinimizePlayerQuizState({
+    required super.status,
+    required super.failureCount,
+    required super.elapsedMs,
+    required super.startedAt,
+    required this.musicState,
+    required this.remainingSeconds,
+  });
+
+  final MusicAppState musicState;
+  final int remainingSeconds;
+
+  MinimizePlayerQuizState copyWith({
+    QuizStatus? status,
+    int? failureCount,
+    int? elapsedMs,
+    DateTime? startedAt,
+    MusicAppState? musicState,
+    int? remainingSeconds,
+  }) {
+    return MinimizePlayerQuizState(
+      status: status ?? this.status,
+      failureCount: failureCount ?? this.failureCount,
+      elapsedMs: elapsedMs ?? this.elapsedMs,
+      startedAt: startedAt ?? this.startedAt,
+      musicState: musicState ?? this.musicState,
+      remainingSeconds: remainingSeconds ?? this.remainingSeconds,
+    );
+  }
+
+  factory MinimizePlayerQuizState.initial() => const MinimizePlayerQuizState(
+        status: QuizStatus.idle,
+        failureCount: 0,
+        elapsedMs: 0,
+        startedAt: null,
+        musicState: MusicAppState.initial,
+        remainingSeconds: MusicQuizConfig.quiz2TimeLimitSeconds,
+      );
+}

--- a/packages/quizzes/music/lib/src/presentation/quiz3_one_repeat/one_repeat_quiz_notifier.dart
+++ b/packages/quizzes/music/lib/src/presentation/quiz3_one_repeat/one_repeat_quiz_notifier.dart
@@ -29,28 +29,29 @@ class OneRepeatQuizNotifier extends AutoDisposeNotifier<OneRepeatQuizState> {
       _timer?.cancel();
       _player?.dispose();
     });
-    _initPlayer();
     return OneRepeatQuizState.initial();
   }
 
   void _initPlayer() {
     try {
-      _player = AudioPlayer();
-      _player!.setLoopMode(LoopMode.off);
+      final player = AudioPlayer();
+      player.setLoopMode(LoopMode.off);
       final source = ConcatenatingAudioSource(
         children: [
           AudioSource.asset(MusicCatalog.audioPaths[0]),
           AudioSource.asset(MusicCatalog.audioPaths[1]),
         ],
       );
-      _player!.setAudioSource(source).then((_) {
-        _player!.play();
+      _player = player;
+      player.setAudioSource(source).then((_) {
+        player.play();
       }).catchError((_) {});
     } catch (_) {}
   }
 
   void startQuiz() {
     if (state.status != QuizStatus.idle) return;
+    _initPlayer();
     state = OneRepeatQuizState.initial().copyWith(
       status: QuizStatus.playing,
       startedAt: clock.now(),
@@ -123,7 +124,15 @@ class OneRepeatQuizNotifier extends AutoDisposeNotifier<OneRepeatQuizState> {
         elapsedMs: elapsed,
       );
       unawaited(hapticFeedback.playSuccessFeedback());
-      await _saveResult(isCleared: true, elapsedMs: elapsed);
+      try {
+        await _saveResult(isCleared: true, elapsedMs: elapsed);
+      } catch (error, stackTrace) {
+        appLogger.e(
+          'Failed to save correct result',
+          error: error,
+          stackTrace: stackTrace,
+        );
+      }
     } else {
       state = state.copyWith(
         musicState: state.musicState.copyWith(repeatMode: nextMode),
@@ -133,6 +142,7 @@ class OneRepeatQuizNotifier extends AutoDisposeNotifier<OneRepeatQuizState> {
 
   void updateLyricsSize(double size) {
     if (state.status != QuizStatus.playing) return;
+    if ((size - state.musicState.lyricsSheetSize).abs() < 0.01) return;
     state = state.copyWith(
       musicState: state.musicState.copyWith(lyricsSheetSize: size),
     );
@@ -165,8 +175,9 @@ class OneRepeatQuizNotifier extends AutoDisposeNotifier<OneRepeatQuizState> {
 
   void retry() {
     _timer?.cancel();
+    _player?.dispose();
+    _player = null;
     ref.read(analyticsServiceProvider).logQuizRetried(quizId: _quizId);
-    _initPlayer();
     state = OneRepeatQuizState.initial();
   }
 

--- a/packages/quizzes/music/lib/src/presentation/quiz3_one_repeat/one_repeat_quiz_notifier.dart
+++ b/packages/quizzes/music/lib/src/presentation/quiz3_one_repeat/one_repeat_quiz_notifier.dart
@@ -1,0 +1,229 @@
+import 'dart:async';
+
+import 'package:clock/clock.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:just_audio/just_audio.dart';
+import 'package:quiz_core/quiz_core.dart';
+import 'package:system/system.dart';
+
+import '../../application/quiz_one_repeat_use_case.dart';
+import '../../domain/music_catalog.dart';
+import '../../infrastructure/music_quiz_repository_provider.dart';
+import 'one_repeat_quiz_state.dart';
+
+final oneRepeatQuizProvider =
+    AutoDisposeNotifierProvider<OneRepeatQuizNotifier, OneRepeatQuizState>(
+  OneRepeatQuizNotifier.new,
+);
+
+class OneRepeatQuizNotifier extends AutoDisposeNotifier<OneRepeatQuizState> {
+  static const _quizId = 'music_quiz3';
+
+  final _useCase = const QuizOneRepeatUseCase();
+  AudioPlayer? _player;
+  Timer? _timer;
+
+  @override
+  OneRepeatQuizState build() {
+    ref.onDispose(() {
+      _timer?.cancel();
+      _player?.dispose();
+    });
+    _initPlayer();
+    return OneRepeatQuizState.initial();
+  }
+
+  void _initPlayer() {
+    try {
+      _player = AudioPlayer();
+      _player!.setLoopMode(LoopMode.off);
+      final source = ConcatenatingAudioSource(
+        children: [
+          AudioSource.asset(MusicCatalog.songs[0].audioAssetPath),
+          AudioSource.asset(MusicCatalog.songs[1].audioAssetPath),
+        ],
+      );
+      _player!.setAudioSource(source).then((_) {
+        _player!.play();
+      }).catchError((_) {});
+    } catch (_) {}
+  }
+
+  void startQuiz() {
+    if (state.status != QuizStatus.idle) return;
+    state = OneRepeatQuizState.initial().copyWith(
+      status: QuizStatus.playing,
+      startedAt: clock.now(),
+    );
+    ref.read(analyticsServiceProvider).logQuizStarted(quizId: _quizId);
+    _startTimer();
+  }
+
+  Future<void> nextSong() async {
+    if (state.status != QuizStatus.playing) return;
+    final nextIndex =
+        (state.musicState.currentSongIndex + 1) % MusicCatalog.songs.length;
+    await _player?.seekToNext();
+    state = state.copyWith(
+      musicState: state.musicState.copyWith(currentSongIndex: nextIndex),
+    );
+  }
+
+  Future<void> previousSong() async {
+    if (state.status != QuizStatus.playing) return;
+    final prevIndex =
+        (state.musicState.currentSongIndex - 1 + MusicCatalog.songs.length) %
+        MusicCatalog.songs.length;
+    await _player?.seekToPrevious();
+    state = state.copyWith(
+      musicState: state.musicState.copyWith(currentSongIndex: prevIndex),
+    );
+  }
+
+  void togglePlayPause() {
+    if (state.status != QuizStatus.playing) return;
+    if (state.musicState.isPlaying) {
+      _player?.pause();
+    } else {
+      _player?.play();
+    }
+    state = state.copyWith(
+      musicState: state.musicState.copyWith(
+        isPlaying: !state.musicState.isPlaying,
+      ),
+    );
+  }
+
+  void togglePlayerExpansion(bool expanded) {
+    if (state.status != QuizStatus.playing) return;
+    state = state.copyWith(
+      musicState: state.musicState.copyWith(isPlayerExpanded: expanded),
+    );
+  }
+
+  Future<void> cycleRepeatMode() async {
+    if (state.status != QuizStatus.playing) return;
+    final nextMode = switch (state.musicState.repeatMode) {
+      LoopMode.off => LoopMode.all,
+      LoopMode.all => LoopMode.one,
+      LoopMode.one => LoopMode.off,
+    };
+    _player?.setLoopMode(nextMode);
+
+    final isClear = _useCase.isClear(repeatMode: nextMode);
+
+    if (isClear) {
+      _timer?.cancel();
+      final elapsed = state.startedAt != null
+          ? clock.now().difference(state.startedAt!).inMilliseconds
+          : 0;
+      state = state.copyWith(
+        musicState: state.musicState.copyWith(repeatMode: nextMode),
+        status: QuizStatus.correct,
+        elapsedMs: elapsed,
+      );
+      unawaited(hapticFeedback.playSuccessFeedback());
+      await _saveResult(isCleared: true, elapsedMs: elapsed);
+    } else {
+      state = state.copyWith(
+        musicState: state.musicState.copyWith(repeatMode: nextMode),
+      );
+    }
+  }
+
+  void updateLyricsSize(double size) {
+    if (state.status != QuizStatus.playing) return;
+    state = state.copyWith(
+      musicState: state.musicState.copyWith(lyricsSheetSize: size),
+    );
+  }
+
+  Future<void> giveUp() async {
+    if (state.status != QuizStatus.playing) return;
+    _timer?.cancel();
+    final elapsed = state.startedAt != null
+        ? clock.now().difference(state.startedAt!).inMilliseconds
+        : 0;
+    state = state.copyWith(
+      status: QuizStatus.giveUp,
+      remainingSeconds: 0,
+      elapsedMs: elapsed,
+    );
+    unawaited(
+      ref.read(analyticsServiceProvider).logQuizGivenUp(quizId: _quizId),
+    );
+    try {
+      await _saveResult(isCleared: false, elapsedMs: elapsed);
+    } catch (error, stackTrace) {
+      appLogger.e(
+        'Failed to save giveUp result',
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
+  }
+
+  void retry() {
+    _timer?.cancel();
+    ref.read(analyticsServiceProvider).logQuizRetried(quizId: _quizId);
+    _initPlayer();
+    state = OneRepeatQuizState.initial();
+  }
+
+  void _startTimer() {
+    _timer?.cancel();
+    _timer = Timer.periodic(const Duration(seconds: 1), (_) {
+      final remaining = state.remainingSeconds - 1;
+      if (remaining <= 0) {
+        _timer?.cancel();
+        _onTimeUp();
+      } else {
+        state = state.copyWith(remainingSeconds: remaining);
+      }
+    });
+  }
+
+  Future<void> _onTimeUp() async {
+    final elapsed = state.startedAt != null
+        ? clock.now().difference(state.startedAt!).inMilliseconds
+        : 0;
+    state = state.copyWith(
+      status: QuizStatus.timeUp,
+      remainingSeconds: 0,
+      elapsedMs: elapsed,
+    );
+    try {
+      await _saveResult(isCleared: false, elapsedMs: elapsed);
+    } catch (error, stackTrace) {
+      appLogger.e(
+        'Failed to save timeUp result',
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
+  }
+
+  Future<void> _saveResult({
+    required bool isCleared,
+    required int elapsedMs,
+  }) async {
+    final repo = ref.read(musicQuizRepositoryProvider);
+    await repo.saveResult(
+      quizId: _quizId,
+      isCleared: isCleared,
+      clearTimeMs: isCleared ? elapsedMs : null,
+      score: isCleared ? state.score : 0,
+      failureCount: state.failureCount,
+    );
+    if (isCleared) {
+      unawaited(
+        ref.read(analyticsServiceProvider).logQuizCompleted(
+              quizId: _quizId,
+              score: state.score,
+              failureCount: state.failureCount,
+              clearTimeMs: elapsedMs,
+            ),
+      );
+    }
+  }
+}

--- a/packages/quizzes/music/lib/src/presentation/quiz3_one_repeat/one_repeat_quiz_notifier.dart
+++ b/packages/quizzes/music/lib/src/presentation/quiz3_one_repeat/one_repeat_quiz_notifier.dart
@@ -39,8 +39,8 @@ class OneRepeatQuizNotifier extends AutoDisposeNotifier<OneRepeatQuizState> {
       _player!.setLoopMode(LoopMode.off);
       final source = ConcatenatingAudioSource(
         children: [
-          AudioSource.asset(MusicCatalog.songs[0].audioAssetPath),
-          AudioSource.asset(MusicCatalog.songs[1].audioAssetPath),
+          AudioSource.asset(MusicCatalog.audioPaths[0]),
+          AudioSource.asset(MusicCatalog.audioPaths[1]),
         ],
       );
       _player!.setAudioSource(source).then((_) {
@@ -62,7 +62,7 @@ class OneRepeatQuizNotifier extends AutoDisposeNotifier<OneRepeatQuizState> {
   Future<void> nextSong() async {
     if (state.status != QuizStatus.playing) return;
     final nextIndex =
-        (state.musicState.currentSongIndex + 1) % MusicCatalog.songs.length;
+        (state.musicState.currentSongIndex + 1) % MusicCatalog.songCount;
     await _player?.seekToNext();
     state = state.copyWith(
       musicState: state.musicState.copyWith(currentSongIndex: nextIndex),
@@ -72,8 +72,8 @@ class OneRepeatQuizNotifier extends AutoDisposeNotifier<OneRepeatQuizState> {
   Future<void> previousSong() async {
     if (state.status != QuizStatus.playing) return;
     final prevIndex =
-        (state.musicState.currentSongIndex - 1 + MusicCatalog.songs.length) %
-        MusicCatalog.songs.length;
+        (state.musicState.currentSongIndex - 1 + MusicCatalog.songCount) %
+        MusicCatalog.songCount;
     await _player?.seekToPrevious();
     state = state.copyWith(
       musicState: state.musicState.copyWith(currentSongIndex: prevIndex),

--- a/packages/quizzes/music/lib/src/presentation/quiz3_one_repeat/one_repeat_quiz_screen.dart
+++ b/packages/quizzes/music/lib/src/presentation/quiz3_one_repeat/one_repeat_quiz_screen.dart
@@ -30,7 +30,7 @@ class _OneRepeatQuizScreenState extends ConsumerState<OneRepeatQuizScreen> {
 
     return MusicAppScaffold(
       musicState: state.musicState,
-      songs: MusicCatalog.songs,
+      songs: MusicCatalog.buildSongs(context.sq),
       quizStatus: state.status,
       remainingSeconds: state.remainingSeconds,
       timeLimitSeconds: MusicQuizConfig.quiz3TimeLimitSeconds,

--- a/packages/quizzes/music/lib/src/presentation/quiz3_one_repeat/one_repeat_quiz_screen.dart
+++ b/packages/quizzes/music/lib/src/presentation/quiz3_one_repeat/one_repeat_quiz_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:quiz_core/quiz_core.dart';
 import 'package:system/system.dart';
 
+import '../../domain/entities/music_song.dart';
 import '../../domain/music_catalog.dart';
 import '../../domain/music_quiz_config.dart';
 import '../../i18n/music_translations_extension.dart';
@@ -22,6 +23,13 @@ class OneRepeatQuizScreen extends ConsumerStatefulWidget {
 class _OneRepeatQuizScreenState extends ConsumerState<OneRepeatQuizScreen> {
   bool _showCutIn = true;
   bool _hintUsed = false;
+  late List<MusicSong> _songs;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _songs = MusicCatalog.buildSongs(context.sq);
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -30,7 +38,7 @@ class _OneRepeatQuizScreenState extends ConsumerState<OneRepeatQuizScreen> {
 
     return MusicAppScaffold(
       musicState: state.musicState,
-      songs: MusicCatalog.buildSongs(context.sq),
+      songs: _songs,
       quizStatus: state.status,
       remainingSeconds: state.remainingSeconds,
       timeLimitSeconds: MusicQuizConfig.quiz3TimeLimitSeconds,

--- a/packages/quizzes/music/lib/src/presentation/quiz3_one_repeat/one_repeat_quiz_screen.dart
+++ b/packages/quizzes/music/lib/src/presentation/quiz3_one_repeat/one_repeat_quiz_screen.dart
@@ -1,0 +1,117 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:quiz_core/quiz_core.dart';
+import 'package:system/system.dart';
+
+import '../../domain/music_catalog.dart';
+import '../../domain/music_quiz_config.dart';
+import '../../i18n/music_translations_extension.dart';
+import '../music_app_scaffold.dart';
+import 'one_repeat_quiz_notifier.dart';
+
+class OneRepeatQuizScreen extends ConsumerStatefulWidget {
+  const OneRepeatQuizScreen({super.key, this.onCompleted});
+
+  final VoidCallback? onCompleted;
+
+  @override
+  ConsumerState<OneRepeatQuizScreen> createState() =>
+      _OneRepeatQuizScreenState();
+}
+
+class _OneRepeatQuizScreenState extends ConsumerState<OneRepeatQuizScreen> {
+  bool _showCutIn = true;
+  bool _hintUsed = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(oneRepeatQuizProvider);
+    final missionText = context.s.quiz3.missionText;
+
+    return MusicAppScaffold(
+      musicState: state.musicState,
+      songs: MusicCatalog.songs,
+      quizStatus: state.status,
+      remainingSeconds: state.remainingSeconds,
+      timeLimitSeconds: MusicQuizConfig.quiz3TimeLimitSeconds,
+      missionText: missionText,
+      onGiveUp: () => ref.read(oneRepeatQuizProvider.notifier).giveUp(),
+      onTogglePlayPause: () =>
+          ref.read(oneRepeatQuizProvider.notifier).togglePlayPause(),
+      onNextSong: () => ref.read(oneRepeatQuizProvider.notifier).nextSong(),
+      onPreviousSong: () =>
+          ref.read(oneRepeatQuizProvider.notifier).previousSong(),
+      onTogglePlayerExpansion: (expanded) => ref
+          .read(oneRepeatQuizProvider.notifier)
+          .togglePlayerExpansion(expanded),
+      onCycleRepeatMode: () =>
+          ref.read(oneRepeatQuizProvider.notifier).cycleRepeatMode(),
+      onLyricsSizeChanged: (size) =>
+          ref.read(oneRepeatQuizProvider.notifier).updateLyricsSize(size),
+      hintUsed: _hintUsed,
+      onHintTap: () => setState(() => _hintUsed = true),
+      highlightRepeat: _hintUsed && state.status == QuizStatus.playing,
+      overlays: [
+        if (_showCutIn)
+          MissionCutIn(
+            missionText: missionText,
+            timeLimitSeconds: MusicQuizConfig.quiz3TimeLimitSeconds,
+            onFinished: () {
+              if (!mounted) return;
+              setState(() => _showCutIn = false);
+              ref.read(oneRepeatQuizProvider.notifier).startQuiz();
+            },
+          ),
+        if (state.status == QuizStatus.correct ||
+            state.status == QuizStatus.incorrect ||
+            state.status == QuizStatus.timeUp ||
+            state.status == QuizStatus.giveUp)
+          Positioned.fill(
+            child: QuizResultOverlay(
+              status: state.status,
+              score: state.score,
+              elapsedMs: state.elapsedMs,
+              onRetry: () {
+                setState(() {
+                  _showCutIn = true;
+                  _hintUsed = false;
+                });
+                ref.read(oneRepeatQuizProvider.notifier).retry();
+              },
+              onNext: state.status == QuizStatus.correct
+                  ? widget.onCompleted
+                  : null,
+              onBack: () => Navigator.of(context).pop(),
+              isLimitReached: ref.isPlayLimitReached,
+              insight: Builder(
+                builder: (context) {
+                  final insight = context.s.quiz3.insight;
+                  return QuizInsightContent(
+                    title: insight.title,
+                    subtitle: insight.subtitle,
+                    items: [
+                      QuizInsightItem(
+                        emoji: '🔁',
+                        title: insight.repeatTitle,
+                        desc: insight.repeatDesc,
+                      ),
+                      QuizInsightItem(
+                        emoji: '🔂',
+                        title: insight.iconTitle,
+                        desc: insight.iconDesc,
+                      ),
+                      QuizInsightItem(
+                        emoji: '👆',
+                        title: insight.tapTitle,
+                        desc: insight.tapDesc,
+                      ),
+                    ],
+                  );
+                },
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}

--- a/packages/quizzes/music/lib/src/presentation/quiz3_one_repeat/one_repeat_quiz_state.dart
+++ b/packages/quizzes/music/lib/src/presentation/quiz3_one_repeat/one_repeat_quiz_state.dart
@@ -1,0 +1,45 @@
+import 'package:quiz_core/quiz_core.dart';
+
+import '../../domain/music_quiz_config.dart';
+import '../music_app_state.dart';
+
+class OneRepeatQuizState extends QuizStateBase {
+  const OneRepeatQuizState({
+    required super.status,
+    required super.failureCount,
+    required super.elapsedMs,
+    required super.startedAt,
+    required this.musicState,
+    required this.remainingSeconds,
+  });
+
+  final MusicAppState musicState;
+  final int remainingSeconds;
+
+  OneRepeatQuizState copyWith({
+    QuizStatus? status,
+    int? failureCount,
+    int? elapsedMs,
+    DateTime? startedAt,
+    MusicAppState? musicState,
+    int? remainingSeconds,
+  }) {
+    return OneRepeatQuizState(
+      status: status ?? this.status,
+      failureCount: failureCount ?? this.failureCount,
+      elapsedMs: elapsedMs ?? this.elapsedMs,
+      startedAt: startedAt ?? this.startedAt,
+      musicState: musicState ?? this.musicState,
+      remainingSeconds: remainingSeconds ?? this.remainingSeconds,
+    );
+  }
+
+  factory OneRepeatQuizState.initial() => const OneRepeatQuizState(
+        status: QuizStatus.idle,
+        failureCount: 0,
+        elapsedMs: 0,
+        startedAt: null,
+        musicState: MusicAppState.initial,
+        remainingSeconds: MusicQuizConfig.quiz3TimeLimitSeconds,
+      );
+}

--- a/packages/quizzes/music/lib/src/presentation/quiz4_lyrics/lyrics_quiz_notifier.dart
+++ b/packages/quizzes/music/lib/src/presentation/quiz4_lyrics/lyrics_quiz_notifier.dart
@@ -1,0 +1,229 @@
+import 'dart:async';
+
+import 'package:clock/clock.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:just_audio/just_audio.dart';
+import 'package:quiz_core/quiz_core.dart';
+import 'package:system/system.dart';
+
+import '../../application/quiz_lyrics_use_case.dart';
+import '../../domain/music_catalog.dart';
+import '../../infrastructure/music_quiz_repository_provider.dart';
+import 'lyrics_quiz_state.dart';
+
+final lyricsQuizProvider =
+    AutoDisposeNotifierProvider<LyricsQuizNotifier, LyricsQuizState>(
+  LyricsQuizNotifier.new,
+);
+
+class LyricsQuizNotifier extends AutoDisposeNotifier<LyricsQuizState> {
+  static const _quizId = 'music_quiz4';
+
+  final _useCase = const QuizLyricsUseCase();
+  AudioPlayer? _player;
+  Timer? _timer;
+
+  @override
+  LyricsQuizState build() {
+    ref.onDispose(() {
+      _timer?.cancel();
+      _player?.dispose();
+    });
+    _initPlayer();
+    return LyricsQuizState.initial();
+  }
+
+  void _initPlayer() {
+    try {
+      _player = AudioPlayer();
+      _player!.setLoopMode(LoopMode.off);
+      final source = ConcatenatingAudioSource(
+        children: [
+          AudioSource.asset(MusicCatalog.songs[0].audioAssetPath),
+          AudioSource.asset(MusicCatalog.songs[1].audioAssetPath),
+        ],
+      );
+      _player!.setAudioSource(source).then((_) {
+        _player!.play();
+      }).catchError((_) {});
+    } catch (_) {}
+  }
+
+  void startQuiz() {
+    if (state.status != QuizStatus.idle) return;
+    state = LyricsQuizState.initial().copyWith(
+      status: QuizStatus.playing,
+      startedAt: clock.now(),
+    );
+    ref.read(analyticsServiceProvider).logQuizStarted(quizId: _quizId);
+    _startTimer();
+  }
+
+  Future<void> nextSong() async {
+    if (state.status != QuizStatus.playing) return;
+    final nextIndex =
+        (state.musicState.currentSongIndex + 1) % MusicCatalog.songs.length;
+    await _player?.seekToNext();
+    state = state.copyWith(
+      musicState: state.musicState.copyWith(currentSongIndex: nextIndex),
+    );
+  }
+
+  Future<void> previousSong() async {
+    if (state.status != QuizStatus.playing) return;
+    final prevIndex =
+        (state.musicState.currentSongIndex - 1 + MusicCatalog.songs.length) %
+        MusicCatalog.songs.length;
+    await _player?.seekToPrevious();
+    state = state.copyWith(
+      musicState: state.musicState.copyWith(currentSongIndex: prevIndex),
+    );
+  }
+
+  void togglePlayPause() {
+    if (state.status != QuizStatus.playing) return;
+    if (state.musicState.isPlaying) {
+      _player?.pause();
+    } else {
+      _player?.play();
+    }
+    state = state.copyWith(
+      musicState: state.musicState.copyWith(
+        isPlaying: !state.musicState.isPlaying,
+      ),
+    );
+  }
+
+  void togglePlayerExpansion(bool expanded) {
+    if (state.status != QuizStatus.playing) return;
+    state = state.copyWith(
+      musicState: state.musicState.copyWith(isPlayerExpanded: expanded),
+    );
+  }
+
+  void cycleRepeatMode() {
+    if (state.status != QuizStatus.playing) return;
+    final nextMode = switch (state.musicState.repeatMode) {
+      LoopMode.off => LoopMode.all,
+      LoopMode.all => LoopMode.one,
+      LoopMode.one => LoopMode.off,
+    };
+    _player?.setLoopMode(nextMode);
+    state = state.copyWith(
+      musicState: state.musicState.copyWith(repeatMode: nextMode),
+    );
+  }
+
+  Future<void> updateLyricsSize(double size) async {
+    if (state.status != QuizStatus.playing) return;
+
+    final isClear = _useCase.isClear(lyricsSheetSize: size);
+
+    if (isClear && state.musicState.lyricsSheetSize < 0.5) {
+      _timer?.cancel();
+      final elapsed = state.startedAt != null
+          ? clock.now().difference(state.startedAt!).inMilliseconds
+          : 0;
+      state = state.copyWith(
+        musicState: state.musicState.copyWith(lyricsSheetSize: size),
+        status: QuizStatus.correct,
+        elapsedMs: elapsed,
+      );
+      unawaited(hapticFeedback.playSuccessFeedback());
+      await _saveResult(isCleared: true, elapsedMs: elapsed);
+    } else {
+      state = state.copyWith(
+        musicState: state.musicState.copyWith(lyricsSheetSize: size),
+      );
+    }
+  }
+
+  Future<void> giveUp() async {
+    if (state.status != QuizStatus.playing) return;
+    _timer?.cancel();
+    final elapsed = state.startedAt != null
+        ? clock.now().difference(state.startedAt!).inMilliseconds
+        : 0;
+    state = state.copyWith(
+      status: QuizStatus.giveUp,
+      remainingSeconds: 0,
+      elapsedMs: elapsed,
+    );
+    unawaited(
+      ref.read(analyticsServiceProvider).logQuizGivenUp(quizId: _quizId),
+    );
+    try {
+      await _saveResult(isCleared: false, elapsedMs: elapsed);
+    } catch (error, stackTrace) {
+      appLogger.e(
+        'Failed to save giveUp result',
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
+  }
+
+  void retry() {
+    _timer?.cancel();
+    ref.read(analyticsServiceProvider).logQuizRetried(quizId: _quizId);
+    _initPlayer();
+    state = LyricsQuizState.initial();
+  }
+
+  void _startTimer() {
+    _timer?.cancel();
+    _timer = Timer.periodic(const Duration(seconds: 1), (_) {
+      final remaining = state.remainingSeconds - 1;
+      if (remaining <= 0) {
+        _timer?.cancel();
+        _onTimeUp();
+      } else {
+        state = state.copyWith(remainingSeconds: remaining);
+      }
+    });
+  }
+
+  Future<void> _onTimeUp() async {
+    final elapsed = state.startedAt != null
+        ? clock.now().difference(state.startedAt!).inMilliseconds
+        : 0;
+    state = state.copyWith(
+      status: QuizStatus.timeUp,
+      remainingSeconds: 0,
+      elapsedMs: elapsed,
+    );
+    try {
+      await _saveResult(isCleared: false, elapsedMs: elapsed);
+    } catch (error, stackTrace) {
+      appLogger.e(
+        'Failed to save timeUp result',
+        error: error,
+        stackTrace: stackTrace,
+      );
+    }
+  }
+
+  Future<void> _saveResult({
+    required bool isCleared,
+    required int elapsedMs,
+  }) async {
+    final repo = ref.read(musicQuizRepositoryProvider);
+    await repo.saveResult(
+      quizId: _quizId,
+      isCleared: isCleared,
+      clearTimeMs: isCleared ? elapsedMs : null,
+      score: isCleared ? state.score : 0,
+      failureCount: state.failureCount,
+    );
+    if (isCleared) {
+      unawaited(
+        ref.read(analyticsServiceProvider).logQuizCompleted(
+              quizId: _quizId,
+              score: state.score,
+              failureCount: state.failureCount,
+              clearTimeMs: elapsedMs,
+            ),
+      );
+    }
+  }
+}

--- a/packages/quizzes/music/lib/src/presentation/quiz4_lyrics/lyrics_quiz_notifier.dart
+++ b/packages/quizzes/music/lib/src/presentation/quiz4_lyrics/lyrics_quiz_notifier.dart
@@ -39,8 +39,8 @@ class LyricsQuizNotifier extends AutoDisposeNotifier<LyricsQuizState> {
       _player!.setLoopMode(LoopMode.off);
       final source = ConcatenatingAudioSource(
         children: [
-          AudioSource.asset(MusicCatalog.songs[0].audioAssetPath),
-          AudioSource.asset(MusicCatalog.songs[1].audioAssetPath),
+          AudioSource.asset(MusicCatalog.audioPaths[0]),
+          AudioSource.asset(MusicCatalog.audioPaths[1]),
         ],
       );
       _player!.setAudioSource(source).then((_) {
@@ -62,7 +62,7 @@ class LyricsQuizNotifier extends AutoDisposeNotifier<LyricsQuizState> {
   Future<void> nextSong() async {
     if (state.status != QuizStatus.playing) return;
     final nextIndex =
-        (state.musicState.currentSongIndex + 1) % MusicCatalog.songs.length;
+        (state.musicState.currentSongIndex + 1) % MusicCatalog.songCount;
     await _player?.seekToNext();
     state = state.copyWith(
       musicState: state.musicState.copyWith(currentSongIndex: nextIndex),
@@ -72,8 +72,8 @@ class LyricsQuizNotifier extends AutoDisposeNotifier<LyricsQuizState> {
   Future<void> previousSong() async {
     if (state.status != QuizStatus.playing) return;
     final prevIndex =
-        (state.musicState.currentSongIndex - 1 + MusicCatalog.songs.length) %
-        MusicCatalog.songs.length;
+        (state.musicState.currentSongIndex - 1 + MusicCatalog.songCount) %
+        MusicCatalog.songCount;
     await _player?.seekToPrevious();
     state = state.copyWith(
       musicState: state.musicState.copyWith(currentSongIndex: prevIndex),

--- a/packages/quizzes/music/lib/src/presentation/quiz4_lyrics/lyrics_quiz_notifier.dart
+++ b/packages/quizzes/music/lib/src/presentation/quiz4_lyrics/lyrics_quiz_notifier.dart
@@ -29,28 +29,29 @@ class LyricsQuizNotifier extends AutoDisposeNotifier<LyricsQuizState> {
       _timer?.cancel();
       _player?.dispose();
     });
-    _initPlayer();
     return LyricsQuizState.initial();
   }
 
   void _initPlayer() {
     try {
-      _player = AudioPlayer();
-      _player!.setLoopMode(LoopMode.off);
+      final player = AudioPlayer();
+      player.setLoopMode(LoopMode.off);
       final source = ConcatenatingAudioSource(
         children: [
           AudioSource.asset(MusicCatalog.audioPaths[0]),
           AudioSource.asset(MusicCatalog.audioPaths[1]),
         ],
       );
-      _player!.setAudioSource(source).then((_) {
-        _player!.play();
+      _player = player;
+      player.setAudioSource(source).then((_) {
+        player.play();
       }).catchError((_) {});
     } catch (_) {}
   }
 
   void startQuiz() {
     if (state.status != QuizStatus.idle) return;
+    _initPlayer();
     state = LyricsQuizState.initial().copyWith(
       status: QuizStatus.playing,
       startedAt: clock.now(),
@@ -130,7 +131,15 @@ class LyricsQuizNotifier extends AutoDisposeNotifier<LyricsQuizState> {
         elapsedMs: elapsed,
       );
       unawaited(hapticFeedback.playSuccessFeedback());
-      await _saveResult(isCleared: true, elapsedMs: elapsed);
+      try {
+        await _saveResult(isCleared: true, elapsedMs: elapsed);
+      } catch (error, stackTrace) {
+        appLogger.e(
+          'Failed to save correct result',
+          error: error,
+          stackTrace: stackTrace,
+        );
+      }
     } else {
       state = state.copyWith(
         musicState: state.musicState.copyWith(lyricsSheetSize: size),
@@ -165,8 +174,9 @@ class LyricsQuizNotifier extends AutoDisposeNotifier<LyricsQuizState> {
 
   void retry() {
     _timer?.cancel();
+    _player?.dispose();
+    _player = null;
     ref.read(analyticsServiceProvider).logQuizRetried(quizId: _quizId);
-    _initPlayer();
     state = LyricsQuizState.initial();
   }
 

--- a/packages/quizzes/music/lib/src/presentation/quiz4_lyrics/lyrics_quiz_screen.dart
+++ b/packages/quizzes/music/lib/src/presentation/quiz4_lyrics/lyrics_quiz_screen.dart
@@ -29,7 +29,7 @@ class _LyricsQuizScreenState extends ConsumerState<LyricsQuizScreen> {
 
     return MusicAppScaffold(
       musicState: state.musicState,
-      songs: MusicCatalog.songs,
+      songs: MusicCatalog.buildSongs(context.sq),
       quizStatus: state.status,
       remainingSeconds: state.remainingSeconds,
       timeLimitSeconds: MusicQuizConfig.quiz4TimeLimitSeconds,

--- a/packages/quizzes/music/lib/src/presentation/quiz4_lyrics/lyrics_quiz_screen.dart
+++ b/packages/quizzes/music/lib/src/presentation/quiz4_lyrics/lyrics_quiz_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:quiz_core/quiz_core.dart';
 import 'package:system/system.dart';
 
+import '../../domain/entities/music_song.dart';
 import '../../domain/music_catalog.dart';
 import '../../domain/music_quiz_config.dart';
 import '../../i18n/music_translations_extension.dart';
@@ -21,6 +22,13 @@ class LyricsQuizScreen extends ConsumerStatefulWidget {
 class _LyricsQuizScreenState extends ConsumerState<LyricsQuizScreen> {
   bool _showCutIn = true;
   bool _hintUsed = false;
+  late List<MusicSong> _songs;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _songs = MusicCatalog.buildSongs(context.sq);
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -29,7 +37,7 @@ class _LyricsQuizScreenState extends ConsumerState<LyricsQuizScreen> {
 
     return MusicAppScaffold(
       musicState: state.musicState,
-      songs: MusicCatalog.buildSongs(context.sq),
+      songs: _songs,
       quizStatus: state.status,
       remainingSeconds: state.remainingSeconds,
       timeLimitSeconds: MusicQuizConfig.quiz4TimeLimitSeconds,

--- a/packages/quizzes/music/lib/src/presentation/quiz4_lyrics/lyrics_quiz_screen.dart
+++ b/packages/quizzes/music/lib/src/presentation/quiz4_lyrics/lyrics_quiz_screen.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:quiz_core/quiz_core.dart';
+import 'package:system/system.dart';
+
+import '../../domain/music_catalog.dart';
+import '../../domain/music_quiz_config.dart';
+import '../../i18n/music_translations_extension.dart';
+import '../music_app_scaffold.dart';
+import 'lyrics_quiz_notifier.dart';
+
+class LyricsQuizScreen extends ConsumerStatefulWidget {
+  const LyricsQuizScreen({super.key, this.onCompleted});
+
+  final VoidCallback? onCompleted;
+
+  @override
+  ConsumerState<LyricsQuizScreen> createState() => _LyricsQuizScreenState();
+}
+
+class _LyricsQuizScreenState extends ConsumerState<LyricsQuizScreen> {
+  bool _showCutIn = true;
+  bool _hintUsed = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(lyricsQuizProvider);
+    final missionText = context.s.quiz4.missionText;
+
+    return MusicAppScaffold(
+      musicState: state.musicState,
+      songs: MusicCatalog.songs,
+      quizStatus: state.status,
+      remainingSeconds: state.remainingSeconds,
+      timeLimitSeconds: MusicQuizConfig.quiz4TimeLimitSeconds,
+      missionText: missionText,
+      onGiveUp: () => ref.read(lyricsQuizProvider.notifier).giveUp(),
+      onTogglePlayPause: () =>
+          ref.read(lyricsQuizProvider.notifier).togglePlayPause(),
+      onNextSong: () => ref.read(lyricsQuizProvider.notifier).nextSong(),
+      onPreviousSong: () =>
+          ref.read(lyricsQuizProvider.notifier).previousSong(),
+      onTogglePlayerExpansion: (expanded) =>
+          ref.read(lyricsQuizProvider.notifier).togglePlayerExpansion(expanded),
+      onCycleRepeatMode: () =>
+          ref.read(lyricsQuizProvider.notifier).cycleRepeatMode(),
+      onLyricsSizeChanged: (size) =>
+          ref.read(lyricsQuizProvider.notifier).updateLyricsSize(size),
+      hintUsed: _hintUsed,
+      onHintTap: () => setState(() => _hintUsed = true),
+      highlightLyrics: _hintUsed && state.status == QuizStatus.playing,
+      overlays: [
+        if (_showCutIn)
+          MissionCutIn(
+            missionText: missionText,
+            timeLimitSeconds: MusicQuizConfig.quiz4TimeLimitSeconds,
+            onFinished: () {
+              if (!mounted) return;
+              setState(() => _showCutIn = false);
+              ref.read(lyricsQuizProvider.notifier).startQuiz();
+            },
+          ),
+        if (state.status == QuizStatus.correct ||
+            state.status == QuizStatus.incorrect ||
+            state.status == QuizStatus.timeUp ||
+            state.status == QuizStatus.giveUp)
+          Positioned.fill(
+            child: QuizResultOverlay(
+              status: state.status,
+              score: state.score,
+              elapsedMs: state.elapsedMs,
+              onRetry: () {
+                setState(() {
+                  _showCutIn = true;
+                  _hintUsed = false;
+                });
+                ref.read(lyricsQuizProvider.notifier).retry();
+              },
+              onNext: state.status == QuizStatus.correct
+                  ? widget.onCompleted
+                  : null,
+              onBack: () => Navigator.of(context).pop(),
+              isLimitReached: ref.isPlayLimitReached,
+              insight: Builder(
+                builder: (context) {
+                  final insight = context.s.quiz4.insight;
+                  return QuizInsightContent(
+                    title: insight.title,
+                    subtitle: insight.subtitle,
+                    items: [
+                      QuizInsightItem(
+                        emoji: '☝️',
+                        title: insight.dragTitle,
+                        desc: insight.dragDesc,
+                      ),
+                      QuizInsightItem(
+                        emoji: '〰️',
+                        title: insight.handleTitle,
+                        desc: insight.handleDesc,
+                      ),
+                      QuizInsightItem(
+                        emoji: '📝',
+                        title: insight.lyricsTitle,
+                        desc: insight.lyricsDesc,
+                      ),
+                    ],
+                  );
+                },
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}

--- a/packages/quizzes/music/lib/src/presentation/quiz4_lyrics/lyrics_quiz_state.dart
+++ b/packages/quizzes/music/lib/src/presentation/quiz4_lyrics/lyrics_quiz_state.dart
@@ -1,0 +1,45 @@
+import 'package:quiz_core/quiz_core.dart';
+
+import '../../domain/music_quiz_config.dart';
+import '../music_app_state.dart';
+
+class LyricsQuizState extends QuizStateBase {
+  const LyricsQuizState({
+    required super.status,
+    required super.failureCount,
+    required super.elapsedMs,
+    required super.startedAt,
+    required this.musicState,
+    required this.remainingSeconds,
+  });
+
+  final MusicAppState musicState;
+  final int remainingSeconds;
+
+  LyricsQuizState copyWith({
+    QuizStatus? status,
+    int? failureCount,
+    int? elapsedMs,
+    DateTime? startedAt,
+    MusicAppState? musicState,
+    int? remainingSeconds,
+  }) {
+    return LyricsQuizState(
+      status: status ?? this.status,
+      failureCount: failureCount ?? this.failureCount,
+      elapsedMs: elapsedMs ?? this.elapsedMs,
+      startedAt: startedAt ?? this.startedAt,
+      musicState: musicState ?? this.musicState,
+      remainingSeconds: remainingSeconds ?? this.remainingSeconds,
+    );
+  }
+
+  factory LyricsQuizState.initial() => const LyricsQuizState(
+        status: QuizStatus.idle,
+        failureCount: 0,
+        elapsedMs: 0,
+        startedAt: null,
+        musicState: MusicAppState.initial,
+        remainingSeconds: MusicQuizConfig.quiz4TimeLimitSeconds,
+      );
+}

--- a/packages/quizzes/music/pubspec.yaml
+++ b/packages/quizzes/music/pubspec.yaml
@@ -1,0 +1,36 @@
+name: music
+description: "NantoNack 音楽プレイヤーカテゴリクイズパッケージ"
+publish_to: "none"
+version: 0.1.0
+
+environment:
+  sdk: ^3.11.3
+
+resolution: workspace
+
+dependencies:
+  clock: ^1.1.2
+  flutter:
+    sdk: flutter
+  flutter_riverpod: ^2.6.1
+  just_audio: ^0.9.42
+  quiz_core:
+    path: ../../quiz_core
+  slang: ^4.3.1
+  slang_flutter: ^4.3.1
+  system:
+    path: ../../system
+
+dev_dependencies:
+  alchemist: ^0.14.0
+  altive_lints: ^2.2.0
+  build_runner: ^2.4.15
+  flutter_test:
+    sdk: flutter
+  mocktail: ^1.0.4
+  slang_build_runner: ^4.3.1
+
+flutter:
+  uses-material-design: true
+  assets:
+    - assets/audio/

--- a/packages/quizzes/music/slang.yaml
+++ b/packages/quizzes/music/slang.yaml
@@ -1,0 +1,6 @@
+base_locale: ja
+fallback_strategy: base_locale
+input_directory: assets/i18n
+output_directory: lib/i18n
+output_file_name: strings.g.dart
+lazy: false

--- a/packages/quizzes/music/test/application/quiz_lyrics_use_case_test.dart
+++ b/packages/quizzes/music/test/application/quiz_lyrics_use_case_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:music/src/application/quiz_lyrics_use_case.dart';
+
+void main() {
+  const useCase = QuizLyricsUseCase();
+
+  group('QuizLyricsUseCase', () {
+    test('isClear returns true when lyricsSheetSize is 0.5', () {
+      expect(useCase.isClear(lyricsSheetSize: 0.5), isTrue);
+    });
+
+    test('isClear returns true when lyricsSheetSize is greater than 0.5', () {
+      expect(useCase.isClear(lyricsSheetSize: 0.8), isTrue);
+    });
+
+    test('isClear returns true when lyricsSheetSize is 1.0', () {
+      expect(useCase.isClear(lyricsSheetSize: 1.0), isTrue);
+    });
+
+    test('isClear returns false when lyricsSheetSize is less than 0.5', () {
+      expect(useCase.isClear(lyricsSheetSize: 0.4), isFalse);
+    });
+
+    test('isClear returns false when lyricsSheetSize is 0.0', () {
+      expect(useCase.isClear(lyricsSheetSize: 0.0), isFalse);
+    });
+  });
+}

--- a/packages/quizzes/music/test/application/quiz_minimize_player_use_case_test.dart
+++ b/packages/quizzes/music/test/application/quiz_minimize_player_use_case_test.dart
@@ -1,0 +1,16 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:music/src/application/quiz_minimize_player_use_case.dart';
+
+void main() {
+  const useCase = QuizMinimizePlayerUseCase();
+
+  group('QuizMinimizePlayerUseCase', () {
+    test('isClear returns true when isExpanded is false', () {
+      expect(useCase.isClear(isExpanded: false), isTrue);
+    });
+
+    test('isClear returns false when isExpanded is true', () {
+      expect(useCase.isClear(isExpanded: true), isFalse);
+    });
+  });
+}

--- a/packages/quizzes/music/test/application/quiz_next_song_use_case_test.dart
+++ b/packages/quizzes/music/test/application/quiz_next_song_use_case_test.dart
@@ -1,0 +1,20 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:music/src/application/quiz_next_song_use_case.dart';
+
+void main() {
+  const useCase = QuizNextSongUseCase();
+
+  group('QuizNextSongUseCase', () {
+    test('isClear returns true when currentIndex differs from previousIndex', () {
+      expect(useCase.isClear(previousIndex: 0, currentIndex: 1), isTrue);
+    });
+
+    test('isClear returns false when currentIndex equals previousIndex', () {
+      expect(useCase.isClear(previousIndex: 0, currentIndex: 0), isFalse);
+    });
+
+    test('isClear returns true when going from index 1 to index 0', () {
+      expect(useCase.isClear(previousIndex: 1, currentIndex: 0), isTrue);
+    });
+  });
+}

--- a/packages/quizzes/music/test/application/quiz_one_repeat_use_case_test.dart
+++ b/packages/quizzes/music/test/application/quiz_one_repeat_use_case_test.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:just_audio/just_audio.dart';
+import 'package:music/src/application/quiz_one_repeat_use_case.dart';
+
+void main() {
+  const useCase = QuizOneRepeatUseCase();
+
+  group('QuizOneRepeatUseCase', () {
+    test('isClear returns true when repeatMode is LoopMode.one', () {
+      expect(useCase.isClear(repeatMode: LoopMode.one), isTrue);
+    });
+
+    test('isClear returns false when repeatMode is LoopMode.off', () {
+      expect(useCase.isClear(repeatMode: LoopMode.off), isFalse);
+    });
+
+    test('isClear returns false when repeatMode is LoopMode.all', () {
+      expect(useCase.isClear(repeatMode: LoopMode.all), isFalse);
+    });
+  });
+}

--- a/packages/quizzes/music/test/flutter_test_config.dart
+++ b/packages/quizzes/music/test/flutter_test_config.dart
@@ -1,0 +1,20 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:alchemist/alchemist.dart';
+
+Future<void> testExecutable(FutureOr<void> Function() testMain) async {
+  final isCI = Platform.environment['CI'] == 'true';
+  await AlchemistConfig.runWithConfig(
+    config: AlchemistConfig(
+      ciGoldensConfig: const CiGoldensConfig(
+        diffThreshold: 0.02,
+      ),
+      platformGoldensConfig: PlatformGoldensConfig(
+        enabled: !isCI,
+        diffThreshold: 0.02,
+      ),
+    ),
+    run: testMain,
+  );
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -89,6 +89,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.13.0"
+  audio_session:
+    dependency: transitive
+    description:
+      name: audio_session
+      sha256: "2b7fff16a552486d078bfc09a8cde19f426dc6d6329262b684182597bec5b1ac"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.25"
   audioplayers:
     dependency: transitive
     description:
@@ -845,6 +853,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.11.0"
+  just_audio:
+    dependency: transitive
+    description:
+      name: just_audio
+      sha256: f978d5b4ccea08f267dae0232ec5405c1b05d3f3cd63f82097ea46c015d5c09e
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.46"
+  just_audio_platform_interface:
+    dependency: transitive
+    description:
+      name: just_audio_platform_interface
+      sha256: "2532c8d6702528824445921c5ff10548b518b13f808c2e34c2fd54793b999a6a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.6.0"
+  just_audio_web:
+    dependency: transitive
+    description:
+      name: just_audio_web
+      sha256: "6ba8a2a7e87d57d32f0f7b42856ade3d6a9fbe0f1a11fabae0a4f00bb73f0663"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.16"
   leak_tracker:
     dependency: transitive
     description:
@@ -1181,6 +1213,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.6.1"
+  rxdart:
+    dependency: transitive
+    description:
+      name: rxdart
+      sha256: "5c3004a4a8dbb94bd4bf5412a4def4acdaa12e12f269737a5751369e12d1a962"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.28.0"
   scrollable_positioned_list:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,6 +22,7 @@ workspace:
   - packages/quizzes/comic
   - packages/quizzes/todo
   - packages/quizzes/matching
+  - packages/quizzes/music
   - packages/geolocator_windows_stub
 
 dev_dependencies:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 音楽カテゴリと4つの音楽クイズを追加（次の曲／最小化／ワンリピート／歌詞）
  * 音楽プレイヤーUI（再生操作、曲切替、リピート、歌詞パネル、ミニプレイヤー）
  * ルート・テーマ・ローカライズを含む音楽パッケージ統合
* **テスト**
  * 各ユースケースの単体テストを追加
* **雑務**
  * パッケージ登録・ワークスペース・プラグイン設定を更新
<!-- end of auto-generated comment: release notes by coderabbit.ai -->