### PR TITLE
🐛fix: チュートリアルのカテゴリ選択・プレイボタン選択をコーチマークの dismiss アニメーション完了後に遷移するよう修正（#105）

### DIFF
--- a/apps/app_main/lib/presentation/home/home_screen.dart
+++ b/apps/app_main/lib/presentation/home/home_screen.dart
@@ -178,7 +178,15 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       },
       onFinish: () {
         _tutorialCoachMark = null;
-        if (navigateOnFinish) navigateToPlay();
+        // フラグを先に消費し、dismiss 完了までに画面が破棄・遷移された場合は
+        // 遷移しない（無効な context での push を防ぐ）
+        final shouldNavigate = navigateOnFinish;
+        navigateOnFinish = false;
+        if (shouldNavigate &&
+            mounted &&
+            ModalRoute.of(context)?.isCurrent == true) {
+          navigateToPlay();
+        }
       },
       onSkip: () {
         _tutorialCoachMark = null;

--- a/apps/app_main/lib/presentation/home/home_screen.dart
+++ b/apps/app_main/lib/presentation/home/home_screen.dart
@@ -117,8 +117,6 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
     final t = Translations.of(context);
 
     Future<void> navigateToPlay() async {
-      _tutorialCoachMark?.finish();
-      _tutorialCoachMark = null;
       ref.read(analyticsServiceProvider).logPlayButtonTapped();
       ref
           .read(tutorialNotifierProvider.notifier)
@@ -127,6 +125,11 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
       if (!mounted) return;
       ref.read(dashboardProvider.notifier).refresh();
     }
+
+    // onClickTarget/onClickOverlay 内で finish() や遷移を直接実行すると、
+    // コーチマークの dismiss アニメーション中に AnimationController が
+    // dispose され例外になる。フラグを立てて onFinish で遷移する。
+    var navigateOnFinish = false;
 
     _tutorialCoachMark = TutorialCoachMark(
       targets: [
@@ -167,10 +170,15 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
           ),
         ),
       ),
-      onClickTarget: (_) => navigateToPlay(),
-      onClickOverlay: (_) => navigateToPlay(),
+      onClickTarget: (_) {
+        navigateOnFinish = true;
+      },
+      onClickOverlay: (_) {
+        navigateOnFinish = true;
+      },
       onFinish: () {
         _tutorialCoachMark = null;
+        if (navigateOnFinish) navigateToPlay();
       },
       onSkip: () {
         _tutorialCoachMark = null;

--- a/apps/app_main/lib/presentation/play/category_list_screen.dart
+++ b/apps/app_main/lib/presentation/play/category_list_screen.dart
@@ -76,6 +76,11 @@ class _CategoryListScreenState extends ConsumerState<CategoryListScreen> {
       context.push(kShoppingWaterPath, extra: true);
     }
 
+    // onClickTarget/onClickOverlay で遷移を即実行せず、
+    // コーチマークの dismiss アニメーション完了後（onFinish）に遷移する。
+    // アニメーション完了前に push すると AnimationController 競合が発生するため。
+    var navigateOnFinish = false;
+
     TutorialCoachMark(
       targets: targets,
       colorShadow: Colors.black,
@@ -99,16 +104,16 @@ class _CategoryListScreenState extends ConsumerState<CategoryListScreen> {
       ),
       onClickTarget: (target) {
         if (target.identify == 'category_shopping') {
-          navigateToWaterQuiz();
+          navigateOnFinish = true;
         }
       },
       onClickOverlay: (target) {
         if (target.identify == 'category_shopping') {
-          navigateToWaterQuiz();
+          navigateOnFinish = true;
         }
       },
       onFinish: () {
-        // コーチマーク自体の完了（ターゲットクリック後に呼ばれる）
+        if (navigateOnFinish) navigateToWaterQuiz();
       },
       onSkip: () {
         // ウィジェットツリーのビルド中に provider を更新するとエラーになるため遅延させる

--- a/apps/app_main/lib/presentation/play/category_list_screen.dart
+++ b/apps/app_main/lib/presentation/play/category_list_screen.dart
@@ -113,7 +113,15 @@ class _CategoryListScreenState extends ConsumerState<CategoryListScreen> {
         }
       },
       onFinish: () {
-        if (navigateOnFinish) navigateToWaterQuiz();
+        // フラグを先に消費し、dismiss 完了までに画面が破棄・遷移された場合は
+        // 遷移しない（無効な context での push を防ぐ）
+        final shouldNavigate = navigateOnFinish;
+        navigateOnFinish = false;
+        if (shouldNavigate &&
+            mounted &&
+            ModalRoute.of(context)?.isCurrent == true) {
+          navigateToWaterQuiz();
+        }
       },
       onSkip: () {
         // ウィジェットツリーのビルド中に provider を更新するとエラーになるため遅延させる


### PR DESCRIPTION
onClickTarget/onClickOverlay 内で finish() や画面遷移を直接実行すると、 アニメーション中に AnimationController が dispose され、
dispose 済みコントローラへの reverse() 呼び出しで例外が発生するため。
フラグを立てて onFinish（アニメーション完了後）で遷移する方式に統一。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * チュートリアルの吹き出しやオーバーレイを操作した際の画面遷移タイミングを改善しました。
  * チュートリアル終了前に画面が切り替わることで起きていた不安定な挙動を抑え、より自然に次の画面へ進めるようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->