### PR TITLE
Bugfix/onboard

### DIFF
--- a/apps/app_main/lib/presentation/play/category_list_screen.dart
+++ b/apps/app_main/lib/presentation/play/category_list_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -31,14 +33,43 @@ class _CategoryListScreenState extends ConsumerState<CategoryListScreen> {
   Future<void> _maybeShowTutorial() async {
     final tutState = await ref.read(tutorialNotifierProvider.future);
     if (!mounted) return;
-    if (!tutState.isCompleted &&
-        tutState.screen == TutorialScreen.categoryList) {
-      // プロバイダーロード完了後、ウィジェットが再ビルドされるまで待つ
-      // （_shoppingCardKey がウィジェットに設定されてから表示する）
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (mounted) _showTutorial();
-      });
+    if (tutState.isCompleted ||
+        tutState.screen != TutorialScreen.categoryList) {
+      return;
     }
+
+    // ページ遷移アニメーション中に localToGlobal で位置を取得すると
+    // 遷移途中の座標が固定されてしまうため、遷移完了を待ってから表示する
+    await _waitForRouteTransition();
+    if (!mounted) return;
+
+    // 遷移完了後の最終レイアウトが確定したフレームで表示する
+    // （_shoppingCardKey がウィジェットに設定されてから表示する）
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) _showTutorial();
+    });
+  }
+
+  /// 現在のルートの遷移アニメーション完了を待つ。
+  /// アニメーションがない（初期ルート・遷移済み）場合は即座に完了する。
+  Future<void> _waitForRouteTransition() {
+    final animation = ModalRoute.of(context)?.animation;
+    if (animation == null ||
+        animation.status == AnimationStatus.completed ||
+        animation.status == AnimationStatus.dismissed) {
+      return Future.value();
+    }
+    final completer = Completer<void>();
+    late final AnimationStatusListener listener;
+    listener = (status) {
+      if (status == AnimationStatus.completed ||
+          status == AnimationStatus.dismissed) {
+        animation.removeStatusListener(listener);
+        completer.complete();
+      }
+    };
+    animation.addStatusListener(listener);
+    return completer.future;
   }
 
   void _showTutorial() {

--- a/apps/app_main/test/presentation/play/category_list_screen_test.dart
+++ b/apps/app_main/test/presentation/play/category_list_screen_test.dart
@@ -1,0 +1,198 @@
+import 'package:app_main/application/tutorial/tutorial_notifier.dart';
+import 'package:app_main/presentation/play/category_list_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:quiz_core/quiz_core.dart';
+
+/// spec/8.tutorial/bugfix_category_coachmark_misalignment.md の回帰テスト。
+///
+/// [CategoryListScreen] は `_waitForRouteTransition()` により、
+/// ページ遷移アニメーション完了後にのみチュートリアルのコーチマークを表示する。
+/// - 遷移アニメーション中はコーチマークが表示されないこと
+/// - 遷移完了後にコーチマークが表示されること
+/// - チュートリアル完了済みの場合は表示されないこと（回帰確認）
+/// を検証する。
+
+/// テスト用に任意の [TutorialState] を同期的に返すフェイク Notifier。
+///
+/// 本物の [TutorialNotifier] は SharedPreferences から
+/// `completed` のみを読み込み `screen` は常に home/done になるため、
+/// `TutorialScreen.categoryList` 状態を再現するにはこのフェイクが必要。
+class _FakeTutorialNotifier extends AsyncNotifier<TutorialState>
+    implements TutorialNotifier {
+  _FakeTutorialNotifier(this._initialState);
+
+  final TutorialState _initialState;
+
+  @override
+  Future<TutorialState> build() async => _initialState;
+
+  @override
+  void advanceTo(TutorialScreen screen) {
+    final current = state.valueOrNull;
+    if (current == null) return;
+    state = AsyncData(current.copyWith(screen: screen));
+  }
+
+  @override
+  Future<void> complete() async {
+    final current = state.valueOrNull;
+    if (current == null) return;
+    state = AsyncData(
+      current.copyWith(screen: TutorialScreen.done, isCompleted: true),
+    );
+  }
+}
+
+/// CategoryListScreen へ push 遷移するためのテストホスト画面。
+///
+/// 初期ルートを素の Scaffold にし、[navigatorKey] 経由で
+/// [CategoryListScreen] を push することで、実際の画面遷移アニメーション
+/// （MaterialPageRoute のデフォルト所要時間 300ms）を再現する。
+Widget _buildTestApp({
+  required TutorialState tutorialState,
+  required GlobalKey<NavigatorState> navigatorKey,
+}) {
+  return ProviderScope(
+    overrides: [
+      tutorialNotifierProvider.overrideWith(
+        () => _FakeTutorialNotifier(tutorialState),
+      ),
+    ],
+    child: TranslationProvider(
+      child: MaterialApp(
+        navigatorKey: navigatorKey,
+        theme: AppTheme.light(),
+        home: const Scaffold(body: SizedBox.shrink()),
+      ),
+    ),
+  );
+}
+
+/// ページ遷移アニメーション・コーチマーク表示に関わる非同期処理を
+/// 決定論的に完了させるためのヘルパー。
+///
+/// `tutorial_coach_mark` はパルスアニメーションを `AnimationController.repeat()`
+/// で無限ループさせているため `tester.pumpAndSettle()` は完了せず、
+/// またオーバーレイ挿入に `Future.delayed(Duration.zero, ...)` を使っている
+/// 関係でタイマーが残ったまま次のテストへ進むと
+/// 「A Timer is still pending」という失敗になる。
+/// そのため固定回数・固定間隔の `pump` で必要な時間を経過させる。
+///
+/// 300ms の遷移アニメーションと、コーチマーク自身のフォーカスイン
+/// アニメーション（既定 `Durations.long4` ≒ 450ms）を合わせても
+/// 十分な 2000ms 分を経過させる。
+Future<void> _pumpThroughTransitionAndTutorial(WidgetTester tester) async {
+  for (var i = 0; i < 40; i++) {
+    await tester.pump(const Duration(milliseconds: 50));
+  }
+}
+
+void main() {
+  // コーチマークの本文（Step4）はロケール依存のため、日本語ロケールに固定して
+  // 期待文字列を取得する（ハードコードした文言のコピー差分に依存しないため）。
+  setUpAll(() {
+    LocaleSettings.setLocaleSync(AppLocale.ja);
+  });
+
+  final step4Text = AppLocale.ja.translations.tutorial.step4;
+
+  group('CategoryListScreen コーチマーク表示タイミング', () {
+    testWidgets(
+      'given チュートリアル未完了状態, when push 遷移アニメーション中, '
+      'then コーチマークは表示されない',
+      (tester) async {
+        // given: チュートリアル未完了・対象画面がカテゴリ一覧
+        final navigatorKey = GlobalKey<NavigatorState>();
+        await tester.pumpWidget(
+          _buildTestApp(
+            tutorialState: const TutorialState(
+              screen: TutorialScreen.categoryList,
+              isCompleted: false,
+            ),
+            navigatorKey: navigatorKey,
+          ),
+        );
+        await tester.pump();
+
+        // when: push 遷移で CategoryListScreen を表示し、
+        // 遷移アニメーションの途中（完了前）でフレームを止める
+        navigatorKey.currentState!.push(
+          MaterialPageRoute<void>(
+            builder: (_) => const CategoryListScreen(),
+          ),
+        );
+        await tester.pump(); // 遷移開始（1フレーム目）
+        await tester.pump(const Duration(milliseconds: 100)); // 300ms中の途中
+
+        // then: アニメーション完了を待っているため、コーチマークはまだ出ない
+        expect(find.text(step4Text), findsNothing);
+
+        // 後片付け: 進行中のアニメーション・タイマーを完了させておく
+        await _pumpThroughTransitionAndTutorial(tester);
+      },
+    );
+
+    testWidgets(
+      'given チュートリアル未完了状態, when push 遷移が完了, '
+      'then コーチマークが表示される',
+      (tester) async {
+        // given
+        final navigatorKey = GlobalKey<NavigatorState>();
+        await tester.pumpWidget(
+          _buildTestApp(
+            tutorialState: const TutorialState(
+              screen: TutorialScreen.categoryList,
+              isCompleted: false,
+            ),
+            navigatorKey: navigatorKey,
+          ),
+        );
+        await tester.pump();
+
+        // when: push 遷移を行い、遷移アニメーション＋コーチマーク自体の
+        // フォーカスアニメーションが完了するまで進める
+        navigatorKey.currentState!.push(
+          MaterialPageRoute<void>(
+            builder: (_) => const CategoryListScreen(),
+          ),
+        );
+        await _pumpThroughTransitionAndTutorial(tester);
+
+        // then: Step4 のコーチマークが表示されている
+        expect(find.text(step4Text), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'given チュートリアル完了済み状態, when push 遷移が完了, '
+      'then コーチマークは表示されない（回帰確認）',
+      (tester) async {
+        // given: チュートリアル完了済み
+        final navigatorKey = GlobalKey<NavigatorState>();
+        await tester.pumpWidget(
+          _buildTestApp(
+            tutorialState: const TutorialState(
+              screen: TutorialScreen.done,
+              isCompleted: true,
+            ),
+            navigatorKey: navigatorKey,
+          ),
+        );
+        await tester.pump();
+
+        // when
+        navigatorKey.currentState!.push(
+          MaterialPageRoute<void>(
+            builder: (_) => const CategoryListScreen(),
+          ),
+        );
+        await _pumpThroughTransitionAndTutorial(tester);
+
+        // then
+        expect(find.text(step4Text), findsNothing);
+      },
+    );
+  });
+}

--- a/spec/8.tutorial/bugfix_category_coachmark_misalignment.md
+++ b/spec/8.tutorial/bugfix_category_coachmark_misalignment.md
@@ -1,0 +1,122 @@
+# バグ修正計画: カテゴリ選択画面のコーチマーク表示ズレ
+
+## 症状
+
+アプリ初回起動時のチュートリアル Step 4（クイズカテゴリ選択画面）で、
+端末によってコーチマーク（フォーカスホール＋吹き出し）が Shopping カードから
+ズレた位置に表示されることがある。
+
+## 調査結果（原因）
+
+### 前提: 座標指定ではない
+
+`category_list_screen.dart` は `tutorial_coach_mark` パッケージを使用しており、
+ターゲットは `GlobalKey`（`keyTarget: _shoppingCardKey`）で指定されている。
+生の座標指定にはなっていない。問題は **位置を取得するタイミング** にある。
+
+### 根本原因: ページ遷移アニメーション中に位置を取得している
+
+1. `tutorial_coach_mark`（v1.3.3）はフォーカス開始時に **一度だけ**
+   `RenderBox.localToGlobal()` でターゲット矩形を取得し、以後その固定座標に
+   フォーカスホールを描画する（再計算されるのは `didChangeMetrics`＝画面サイズ・
+   回転変更時のみ。ソース: `src/util.dart` の `getTargetCurrent()`、
+   `src/widgets/animated_focus_light.dart` の `_runFocus()`）。
+
+2. `CategoryListScreen` はホーム画面から `context.push('/play')` で遷移してくる。
+   現在のフロー:
+   - `initState` の `addPostFrameCallback` → 遷移アニメーションの **1フレーム目** に発火
+   - `ref.read(tutorialNotifierProvider.future)` はホーム画面で読み込み済みのため即時解決
+   - さらに 1 回 `addPostFrameCallback` を挟んで `_showTutorial()` 実行
+   - つまり遷移開始から **約2フレーム（16〜33ms）後** にコーチマークが表示される
+
+3. ページ遷移アニメーション（Android デフォルト: Zoom＝scale 0.85→1.0＋フェード、
+   iOS: 右からのスライド。所要 300〜500ms）の最中は、ページの RenderObject に
+   scale / translate 変換がかかっている。`localToGlobal()` はこの変換を含んだ
+   「遷移途中の見た目上の位置」を返すため、取得された矩形は最終位置からズレている
+   （Zoom なら縮小されて中央寄り、スライドなら右寄り）。
+
+4. 遷移完了後、ページは最終位置に収まるが、フォーカスホールは取得済みの古い座標の
+   まま描画され続ける → ズレて見える。
+
+### 「端末によって」ズレ方が変わる理由
+
+- プラットフォームで遷移の種類が異なる（Android: Zoom / iOS: Cupertino slide）
+- 設定の `AppUiStyle`（`app.dart` で `ThemeData.platform` を上書き）でも遷移が変わる
+- 端末の描画速度により、位置取得時点でアニメーションがどこまで進んでいるかが変わる
+
+### 補足: 他画面への影響
+
+- **ホーム画面（Step 1〜3）**: 初期ルートのため遷移アニメーションがなく影響なし
+- **TutorialWaterQuizScreen（Step 5〜7）**: MissionCutIn 完了後（遷移完了から
+  数秒後）に表示するため影響なし
+- 対応は `category_list_screen.dart` のみでよい
+
+## 修正方針
+
+`apps/app_main/lib/presentation/play/category_list_screen.dart` の
+`_maybeShowTutorial()` で、コーチマーク表示前に **ページ遷移アニメーションの完了を
+待つ** 処理を追加する。
+
+```dart
+Future<void> _maybeShowTutorial() async {
+  final tutState = await ref.read(tutorialNotifierProvider.future);
+  if (!mounted) return;
+  if (tutState.isCompleted ||
+      tutState.screen != TutorialScreen.categoryList) {
+    return;
+  }
+
+  // ページ遷移アニメーション中に localToGlobal で位置を取得すると
+  // 遷移途中の座標が固定されてしまうため、遷移完了を待ってから表示する
+  await _waitForRouteTransition();
+  if (!mounted) return;
+
+  // 遷移完了後の最終レイアウトが確定したフレームで表示する
+  WidgetsBinding.instance.addPostFrameCallback((_) {
+    if (mounted) _showTutorial();
+  });
+}
+
+/// 現在のルートの遷移アニメーション完了を待つ。
+/// アニメーションがない（初期ルート・遷移済み）場合は即座に完了する。
+Future<void> _waitForRouteTransition() {
+  final animation = ModalRoute.of(context)?.animation;
+  if (animation == null ||
+      animation.status == AnimationStatus.completed ||
+      animation.status == AnimationStatus.dismissed) {
+    return Future.value();
+  }
+  final completer = Completer<void>();
+  late final AnimationStatusListener listener;
+  listener = (status) {
+    if (status == AnimationStatus.completed ||
+        status == AnimationStatus.dismissed) {
+      animation.removeStatusListener(listener);
+      completer.complete();
+    }
+  };
+  animation.addStatusListener(listener);
+  return completer.future;
+}
+```
+
+### 実装上の注意
+
+- `dart:async`（`Completer`）と `AnimationStatusListener` を使うため import 追加が必要
+- 既存のガード（`mounted` / `ModalRoute.isCurrent` / `_shoppingCardKey.currentContext`
+  の null チェック）は `_showTutorial()` 内にそのまま残す
+- ヘルパーは現状 `_CategoryListScreenState` の private メソッドでよい
+  （他画面で必要になったら `presentation/tutorial/` へ切り出す）
+- アニメーション無効設定（アクセシビリティ等）の端末では status が即 completed に
+  なるため、上記コードで自然に即時表示となる
+
+## テスト方針
+
+- `_waitForRouteTransition` を含むチュートリアル表示フローの Widget テスト:
+  1. チュートリアル未完了状態で CategoryListScreen を **push 遷移** で表示し、
+     遷移アニメーション中（`pump` 途中）はコーチマークが出ないこと
+  2. `pumpAndSettle` で遷移完了後にコーチマーク（TutorialCoachMark のオーバーレイ）
+     が表示されること
+  3. チュートリアル完了済み状態では表示されないこと（既存動作の回帰確認）
+- 既存のチュートリアル関連テストがあれば流用・追記する
+- テストパターンは `.agents/skills/testing-patterns.md` に従う


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * カテゴリ選択画面のチュートリアルコーチマークが、画面遷移中にずれて表示される問題を修正しました。
  * 画面遷移とレイアウト確定後にコーチマークを表示するよう改善しました。
  * チュートリアル完了済みの場合は、コーチマークを表示しません。

* **テスト**
  * 遷移中は表示されず、遷移完了後に正しく表示されることを確認する回帰テストを追加しました。

* **ドキュメント**
  * 問題の原因、修正方針、テスト方針を整理しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->