### PR TITLE
🐛fix: iOSでマイク未使用APIが原因の無効バイナリを解消しTestFlight配信を修正

### DIFF
--- a/apps/app_main/ios/Podfile
+++ b/apps/app_main/ios/Podfile
@@ -45,5 +45,17 @@ end
 post_install do |installer|
   installer.pods_project.targets.each do |target|
     flutter_additional_ios_build_settings(target)
+
+    # just_audio が推移的に依存する audio_session は、既定でマイク許可API
+    # (requestRecordPermission / recordPermission) をバイナリに含める。
+    # 本アプリは録音を行わず Info.plist に NSMicrophoneUsageDescription を持たないため、
+    # そのままだと App Store Connect の処理で無効バイナリ判定 (ITMS-90683) となり
+    # TestFlight に反映されない。AUDIO_SESSION_MICROPHONE=0 でマイクコードを除外する。
+    if target.name == 'audio_session'
+      target.build_configurations.each do |config|
+        config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= ['$(inherited)']
+        config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] << 'AUDIO_SESSION_MICROPHONE=0'
+      end
+    end
   end
 end


### PR DESCRIPTION
just_audio が推移的に依存する audio_session が既定でマイク許可API
(requestRecordPermission / recordPermission) をバイナリに含めるため、 NSMicrophoneUsageDescription を持たない本アプリは App Store Connect の 処理で無効バイナリ判定 (ITMS-90683) となり TestFlight に反映されなかった。 Podfile の post_install で AUDIO_SESSION_MICROPHONE=0 を定義し、 録音を行わない本アプリからマイクコードを除外する。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * iOS版で音声再生機能がマイクへのアクセスを必要としないようになりました。
  * 音声再生時に、マイク許可に関する不要な処理や確認が発生しなくなります。
  * マイクを使用しない環境で、より適切な権限設定で利用できます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->