### PR TITLE
🐛fix: スライドの自動ビルドが firebase_options 不足で落ちるのを修正

### DIFF
--- a/.github/workflows/deploy_slides.yml
+++ b/.github/workflows/deploy_slides.yml
@@ -50,10 +50,21 @@ jobs:
           key: pub-${{ runner.os }}-${{ hashFiles('**/pubspec.yaml') }}
           restore-keys: pub-${{ runner.os }}-
 
+      # スライド自身は Firebase を使わないが、shopping → system の依存があり、
+      # dart2js は**呼ばれないコードも含めてライブラリ全体をコンパイルする**。
+      # firebase_options*.dart は .gitignore されているので復元が要る。
+      # （Android/iOS 用の google-services.json 等は Web ビルドでは不要）
+      - name: Firebase 設定ファイルの復元
+        run: |
+          mkdir -p packages/system/lib/src/firebase
+          echo "${{ secrets.FIREBASE_OPTIONS_DART_BASE64 }}" | base64 -d > packages/system/lib/src/firebase/firebase_options.dart
+          echo "${{ secrets.FIREBASE_OPTIONS_DEV_DART_BASE64 }}" | base64 -d > packages/system/lib/src/firebase/firebase_options_dev.dart
+
       # apps/slides はワークスペース外の独立パッケージなので melos は不要。
       # このディレクトリで pub get すれば path 依存の quiz_core / shopping も解決される。
-      # スライドは Firebase もコード生成も使わないため、ci.yml にある
-      # Secrets の復元と gen:all は意図的に入れていない。
+      # 生成コード（*.g.dart）はコミットされているため gen:all は不要。
+      # env.g.dart 系だけは .gitignore されているが、app_main 配下のみで
+      # スライドの依存グラフには含まれない。
       - name: 依存関係の解決
         run: cd apps/slides && flutter pub get
 


### PR DESCRIPTION
@
## 背景

PR #121 のマージで `Build Slides` が自動起動したが、**ビルドステップで失敗した**（[実行結果](https://github.com/yakitama5/nanto_nack/actions/runs/30778184834)）。

```
Error when reading ../../packages/system/lib/src/firebase/firebase_options.dart
  (No such file or directory)
Error: Undefined name 'DefaultFirebaseOptions'.
```

## 原因

`deploy_slides.yml` に「スライドは Firebase を使わないので Secrets の復元は不要」と書いていたが、**この前提が誤りだった。**

- `apps/slides` → `shopping` → `system` の依存があり、`system` は Firebase を使う
- **dart2js は呼ばれないコードも含めてライブラリ全体をコンパイルする**ため、スライドが Firebase を一切使わなくても `firebase_options.dart` の解決が必要
- 同ファイルは `.gitignore:63` で除外されており、CI では Secrets から復元する運用

ローカルでは当該ファイルが既に存在していたため `melos run build:slides` は成功しており、気づけなかった。

## 変更

`ci.yml` と同じ手順で `firebase_options.dart` / `firebase_options_dev.dart` を復元するステップを追加した。

必要最小限に絞っている。

| 項目 | 判断 |
|---|---|
| `firebase_options*.dart` | **必要**（追加） |
| `google-services.json` / `.plist` | 不要（Android/iOS 用。Web ビルドでは使わない） |
| `.env` | 不要（`app_main` 配下のみ） |
| `gen:all` | 不要（生成コード81件はコミット済み） |
| `env.g.dart` | 不要（gitignore されているが `app_main` 配下のみで依存グラフ外） |

## 確認方法

**この修正は CI では検証できない。** `ci.yml` は元々 firebase_options を復元しているため、PR 上の静的解析・テストは修正前から green だった。

マージ後に `Build Slides` が自動再実行されるので、**そこで Artifact `nanto-nack-slides` が生成されるところまで確認する必要がある。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@