### PR TITLE
✨feat: スライドを GitHub Pages にも公開する

### DIFF
--- a/.github/workflows/deploy_slides.yml
+++ b/.github/workflows/deploy_slides.yml
@@ -21,10 +21,9 @@ on:
       - '.github/workflows/deploy_slides.yml'
   workflow_dispatch:
 
+# 既定は読み取りのみ。公開に必要な権限は deploy ジョブだけに与える。
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 # Pages のデプロイは途中で打ち切ると公開が中途半端な状態になりうるため、
 # cancel-in-progress は false にする（GitHub 公式のスターターと同じ）。
@@ -95,8 +94,9 @@ jobs:
       - name: GitHub Pages 用のビルド (base-href /nanto_nack/)
         run: cd apps/slides && flutter build web --base-href /nanto_nack/
 
-      - uses: actions/configure-pages@v5
-
+      # actions/configure-pages は使わない。base-href を決め打ちしており
+      # 出力（base_url 等）が不要なうえ、Pages API を読むため build ジョブに
+      # pages 権限が必要になってしまうため。
       - uses: actions/upload-pages-artifact@v3
         with:
           path: apps/slides/build/web
@@ -107,6 +107,9 @@ jobs:
     name: GitHub Pages への公開
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/deploy_slides.yml
+++ b/.github/workflows/deploy_slides.yml
@@ -1,14 +1,16 @@
 name: Build Slides
 
-# main のスライド関連の変更で自動ビルドし、成果物を Artifact として上げる。
+# main のスライド関連の変更で自動ビルドし、2つの成果物を出す。
+#
+#   1. Artifact `nanto-nack-slides` … 発表本番用。ダウンロードしてローカルで配信する
+#   2. GitHub Pages                  … 共有・見返し用
+#
+# 本番の投影は 1 を使う。バンドルが大きく、会場の回線に依存させたくないため。
 #
 # apps/slides は path 依存で quiz_core / shopping の UI を**実描画**しているため、
 # それらが変わるとスライドの見た目も変わる。paths に含めていないと
-# 「最新の UI を反映していない Artifact が残り続ける」ことに気づけないので、
+# 「最新の UI を反映していない成果物が残り続ける」ことに気づけないので、
 # 依存元も対象に入れている。
-#
-# 無関係な変更でもビルドが走るが、public リポジトリは Actions の実行時間も
-# ストレージも無料で、concurrency で古い実行は打ち切られるため許容する。
 on:
   push:
     branches: [main]
@@ -21,14 +23,18 @@ on:
 
 permissions:
   contents: read
+  pages: write
+  id-token: write
 
+# Pages のデプロイは途中で打ち切ると公開が中途半端な状態になりうるため、
+# cancel-in-progress は false にする（GitHub 公式のスターターと同じ）。
 concurrency:
-  group: build-slides
-  cancel-in-progress: true
+  group: pages
+  cancel-in-progress: false
 
 jobs:
   build:
-    name: スライドのビルドと Artifact 化
+    name: スライドのビルド
     runs-on: ubuntu-latest
 
     steps:
@@ -68,16 +74,43 @@ jobs:
       - name: 依存関係の解決
         run: cd apps/slides && flutter pub get
 
-      # base-href は "/" 固定。ローカルで HTTP サーバを立てて
-      # http://localhost:8000/ として開く前提のため。
-      # サブパス配信（GitHub Pages 等）に変える場合はここを直すこと。
-      - name: スライドのビルド
-        run: cd apps/slides && flutter build web --base-href /
+      # base-href は配信場所ごとに変わり、**1つの成果物を使い回せない**。
+      # 値が合わないとアセットが全て 404 になるため、2 回ビルドする。
+      #   ローカル配信 (http://localhost:8000/) → /
+      #   Pages        (…/nanto_nack/)          → /nanto_nack/
+      - name: ローカル配信用のビルド (base-href /)
+        run: |
+          cd apps/slides
+          flutter build web --base-href /
+          mv build/web build/web-local
 
-      - name: Artifact のアップロード
+      - name: 発表本番用 Artifact のアップロード
         uses: actions/upload-artifact@v4
         with:
           name: nanto-nack-slides
-          path: apps/slides/build/web
+          path: apps/slides/build/web-local
           if-no-files-found: error
           retention-days: 90
+
+      - name: GitHub Pages 用のビルド (base-href /nanto_nack/)
+        run: cd apps/slides && flutter build web --base-href /nanto_nack/
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: apps/slides/build/web
+
+  # ビルドが失敗すればこのジョブは走らないので、
+  # 壊れたものが公開されることはない（公開済みの内容もそのまま残る）。
+  deploy:
+    name: GitHub Pages への公開
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/apps/slides/README.md
+++ b/apps/slides/README.md
@@ -47,12 +47,17 @@ fvm flutter run -d chrome
 
 ## ビルドと配信
 
-成果物は **GitHub Actions の Artifact** として配布する。Web でホスティングはしない。
-`main` の `apps/slides/**` が変わると自動でビルドされ、Actions の実行結果に
-`nanto-nack-slides` という Artifact が付く。
+`main` のスライド関連の変更で自動ビルドされ、**2つの成果物**が出る。
 
-> `quiz_core` / `shopping` を変更したときは自動では走らない。
-> スライドに反映したい場合は Actions から **Build Slides を手動実行**すること。
+| 成果物 | 用途 | base-href |
+| --- | --- | --- |
+| Artifact `nanto-nack-slides` | **発表本番用**。ネットワーク非依存 | `/` |
+| [GitHub Pages](https://yakitama5.github.io/nanto_nack/) | 共有・見返し用 | `/nanto_nack/` |
+
+**投影は Artifact を使う。** バンドルが約90MBあり、会場の回線に依存させたくないため。
+
+`base-href` は配信場所ごとに変わり **1つの成果物を使い回せない**（値が合わないとアセットが全て404になる）。
+そのためワークフローでは 2 回ビルドしている。
 
 ### ⚠️ index.html をダブルクリックしても動かない
 
@@ -73,8 +78,8 @@ fvm dart run melos run build:slides   # apps/slides/build/web に出力
 fvm dart run melos run serve:slides   # http://localhost:8000/ で配信
 ```
 
-`--base-href` は **`/` 固定**。ローカルの HTTP サーバで配信する前提のため。
-サブパスで配信する（GitHub Pages 等）場合はこの指定を変える必要がある。
+`build:slides` の `--base-href` は **`/` 固定**（ローカル配信用）。
+Pages 用の成果物が要る場合は `--base-href /nanto_nack/` でビルドすること。
 
 ## 実装上の注意
 

--- a/apps/slides/README.md
+++ b/apps/slides/README.md
@@ -79,7 +79,17 @@ fvm dart run melos run serve:slides   # http://localhost:8000/ で配信
 ```
 
 `build:slides` の `--base-href` は **`/` 固定**（ローカル配信用）。
-Pages 用の成果物が要る場合は `--base-href /nanto_nack/` でビルドすること。
+
+Pages と同じ成果物を手元で作る場合は、`apps/slides` で直接ビルドする。
+
+```bash
+cd apps/slides
+fvm flutter pub get
+fvm flutter build web --base-href /nanto_nack/
+```
+
+このまま `localhost` で配信しても**アセットが404になる**（`/nanto_nack/` を探すため）。
+ローカル確認用には `--base-href /` の方を使うこと。
 
 ## 実装上の注意
 


### PR DESCRIPTION
@
## 概要

発表本番用の Artifact はそのまま残し、**共有・見返し用に GitHub Pages を追加**する。

| 成果物 | 用途 | base-href |
| --- | --- | --- |
| Artifact `nanto-nack-slides` | **発表本番用**。ネットワーク非依存 | `/` |
| [GitHub Pages](https://yakitama5.github.io/nanto_nack/) | 共有・見返し用 | `/nanto_nack/` |

**投影は引き続き Artifact を使う。** バンドルが約90MBあり、会場の回線に依存させたくないため。
Pages は「あとで見返せるURL」として追加するもの。

リポジトリ設定（Settings → Pages → Source = GitHub Actions）はオーナーにて対応済み。
`gh api repos/yakitama5/nanto_nack/pages` で `build_type: workflow` を確認した。

## なぜ 2 回ビルドするのか

`--base-href` は配信場所ごとに値が変わり、**1つの成果物を使い回せない。**
値が合わないとアセットと JS が全て 404 になる。

`index.html` を後から書き換える方法もあるが、本番で使うものなので確実な方を選んだ。
2回目のビルドはビルドキャッシュが効くため、追加時間は1分程度の見込み。

ローカルで両立を検証済み。

```
web-local (発表用): <base href="/">
web       (Pages) : <base href="/nanto_nack/">
```

## 安全側に倒した点

- **`deploy` は `build` の完了を待つ。** ビルドが失敗すれば公開されず、公開済みの内容もそのまま残る
- **`cancel-in-progress: false` に変更。** デプロイを途中で打ち切ると公開が中途半端な状態になりうるため（GitHub 公式のスターターワークフローと同じ設定）

## トリガー

Artifact / Pages とも**自動**（main への push・paths 限定）。手動実行も残している。

未完成のスライドが公開される懸念については、main に入るものは必ず PR レビューを通るため、
構造的に起きないと判断した。

## 確認方法

**この変更は CI では検証できない。** マージ後に `Build Slides` が走るので、以下を確認する。

- [ ] `build` / `deploy` の2ジョブとも成功する
- [ ] Artifact `nanto-nack-slides` が生成される（従来どおり）
- [ ] <https://yakitama5.github.io/nanto_nack/> が開き、最後まで送れる
- [ ] `#/wonder` の直リンクが開く

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * スライドをGitHub Pagesで公開できるようになりました。
  * ローカル配信用とGitHub Pages配信用の成果物を個別に生成・提供します。

* **ドキュメント**
  * 配信先に応じたビルド方法と、本番投影時にネットワーク不要の成果物を使用する手順を追記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->